### PR TITLE
chore: remove tap-dot dependency

### DIFF
--- a/grpc/clients/js/package-lock.json
+++ b/grpc/clients/js/package-lock.json
@@ -15,7 +15,6 @@
         "@typescript-eslint/parser": "4.22.1",
         "eslint": "7.26.0",
         "google-protobuf": "3.16.0",
-        "tap-dot": "2.0.0",
         "tape": "5.2.2",
         "tinyify": "3.0.0",
         "ts-protoc-gen": "0.15.0",
@@ -1247,7 +1246,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -2753,12 +2753,6 @@
         }
       ]
     },
-    "node_modules/re-emitter": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz",
-      "integrity": "sha512-C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==",
-      "dev": true
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -3037,18 +3031,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3209,90 +3191,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/tap-dot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tap-dot/-/tap-dot-2.0.0.tgz",
-      "integrity": "sha512-7N1yPcRDgdfHCUbG6lZ0hXo53NyXhKIjJNhqKBixl9HVEG4QasG16Nlvr8wRnqr2ZRYVWmbmxwF3NOBbTLtQLQ==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^1.1.1",
-        "tap-out": "^1.3.2",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "tap-dot": "bin/dot"
-      }
-    },
-    "node_modules/tap-dot/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-dot/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-dot/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-dot/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-dot/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-out": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
-      "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
-      "dev": true,
-      "dependencies": {
-        "re-emitter": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "split": "^1.0.0",
-        "trim": "0.0.1"
-      },
-      "bin": {
-        "tap-out": "bin/cmd.js"
-      }
     },
     "node_modules/tape": {
       "version": "5.2.2",
@@ -3475,12 +3373,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
     "node_modules/ts-protoc-gen": {
@@ -6003,12 +5895,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "re-emitter": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz",
-      "integrity": "sha512-C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==",
-      "dev": true
-    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -6205,15 +6091,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6341,71 +6218,6 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         }
-      }
-    },
-    "tap-dot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tap-dot/-/tap-dot-2.0.0.tgz",
-      "integrity": "sha512-7N1yPcRDgdfHCUbG6lZ0hXo53NyXhKIjJNhqKBixl9HVEG4QasG16Nlvr8wRnqr2ZRYVWmbmxwF3NOBbTLtQLQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "tap-out": "^1.3.2",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "tap-out": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
-      "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
-      "dev": true,
-      "requires": {
-        "re-emitter": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "split": "^1.0.0",
-        "trim": "0.0.1"
       }
     },
     "tape": {
@@ -6563,12 +6375,6 @@
           "dev": true
         }
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
     },
     "ts-protoc-gen": {
       "version": "0.15.0",

--- a/grpc/clients/js/package.json
+++ b/grpc/clients/js/package.json
@@ -11,7 +11,7 @@
     "lint": "npm run lint:javascript && npm run lint:typescript",
     "lint:javascript": "eslint generated/**/*.js",
     "lint:typescript": "eslint generated/**/*.d.ts",
-    "test": "tape 'test/**/*.test.js' | tap-dot",
+    "test": "tape 'test/**/*.test.js'",
     "test:local": "WALLETSERVER=false yarn run test"
   },
   "repository": {
@@ -35,7 +35,6 @@
     "@typescript-eslint/parser": "4.22.1",
     "eslint": "7.26.0",
     "google-protobuf": "3.16.0",
-    "tap-dot": "2.0.0",
     "tape": "5.2.2",
     "tinyify": "3.0.0",
     "ts-protoc-gen": "0.15.0",


### PR DESCRIPTION
Remove `tap-dot` from JS dependencies. It’s a library that makes for slightly more compact test output. We can live without it.

- Remove `tap-dot` from `package.json`
- Regenerate `package-log.json`

Closes #207 