### PR TITLE
Add example submit-order scripts in python and bash

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,8 +8,10 @@ name: Python
       - develop
       - main
     paths:
+      - "external/**"
       - "grpc/clients/python/**"
       - "grpc/examples/python/**"
+      - "proto/**"
       - "rest/examples/python/**"
   push:
     branches:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,7 @@ name: Python
     paths:
       - "grpc/clients/python/**"
       - "grpc/examples/python/**"
+      - "rest/examples/python/**"
   push:
     branches:
       - develop
@@ -37,20 +38,17 @@ jobs:
       - name: Lint with flake8
         run: |
           command -v flake8 1>/dev/null || pip install flake8
-          (cd grpc/clients/python && make flake8)
-          (cd grpc/examples/python && make flake8)
+          make flake8
 
       - name: Lint with black
         run: |
           command -v black 1>/dev/null || pip install black
-          (cd grpc/clients/python && make blackcheck)
-          (cd grpc/examples/python && make blackcheck)
+          make blackcheck
 
       - name: Type-check with mypy
         run: |
           command -v mypy 1>/dev/null || pip install mypy
-          (cd grpc/clients/python && make mypy)
-          (cd grpc/examples/python && make mypy)
+          make mypy
 
       - name: Test with pytest
         env:
@@ -62,22 +60,13 @@ jobs:
           command -v pipenv 1>/dev/null || pip install pipenv
           make test
 
-      - name: Coverage with pytest
-        env:
-          GRPC_NODE: ${{ secrets.GRPC_NODE }}
-          FAUCETSERVER: ${{ secrets.FAUCETSERVER }}
-          WALLETSERVER: ${{ secrets.WALLETSERVER }}
-        run: |
-          cd grpc/clients/python
-          make coverage
-
       - name: Check archive file counts
         run: |
           cd grpc/clients/python
           python3 setup.py sdist bdist_wheel
           make check_dist
 
-      - name: Run example scripts
+      - name: Run example scripts for gRPC
         env:
           NODE_URL_GRPC: ${{ secrets.GRPC_NODE }}
           WALLET_NAME: ${{ secrets.WALLET_NAME }}
@@ -86,7 +75,18 @@ jobs:
         run: |
           command -v pipenv 1>/dev/null || pip install pipenv
           cd grpc/examples/python
-          make examples_ci
+          make
+
+      - name: Run example scripts for REST
+        env:
+          NODE_URL_REST: ${{ secrets.NODE_URL_REST }}
+          WALLET_NAME: ${{ secrets.WALLET_NAME }}
+          WALLET_PASSPHRASE: ${{ secrets.WALLET_PASSPHRASE }}
+          WALLETSERVER_URL: ${{ secrets.WALLETSERVER }}
+        run: |
+          command -v pipenv 1>/dev/null || pip install pipenv
+          cd rest/examples/python
+          make
 
       - name: Push release to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.8' }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,15 +36,21 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          cd grpc/clients/python
           command -v flake8 1>/dev/null || pip install flake8
-          make flake8
+          cd grpc/clients/python && make flake8
+          cd grpc/examples/python && make flake8
 
       - name: Lint with black
         run: |
-          cd grpc/clients/python
           command -v black 1>/dev/null || pip install black
-          make black
+          cd grpc/clients/python && make blackcheck
+          cd grpc/examples/python && make blackcheck
+
+      - name: Type-check with mypy
+        run: |
+          command -v mypy 1>/dev/null || pip install mypy
+          cd grpc/clients/python && make mypy
+          cd grpc/examples/python && make mypy
 
       - name: Test with pytest
         env:
@@ -65,12 +71,6 @@ jobs:
           cd grpc/clients/python
           make coverage
 
-      - name: Type-check with mypy
-        run: |
-          cd grpc/clients/python
-          command -v mypy 1>/dev/null || pip install mypy
-          make mypy
-
       - name: Check archive file counts
         run: |
           cd grpc/clients/python
@@ -80,14 +80,12 @@ jobs:
       - name: Run example scripts
         env:
           NODE_URL_GRPC: ${{ secrets.GRPC_NODE }}
-          PYTHONPATH: ../../clients/python:.
           WALLET_NAME: ${{ secrets.WALLET_NAME }}
           WALLET_PASSPHRASE: ${{ secrets.WALLET_PASSPHRASE }}
           WALLETSERVER_URL: ${{ secrets.WALLETSERVER }}
         run: |
           cd grpc/examples/python
-          pipenv sync && pipenv clean
-          pipenv run python3 submit-order.py --ci
+          make examples_ci
 
       - name: Push release to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.8' }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,6 +59,7 @@ jobs:
           WALLETSERVER: ${{ secrets.WALLETSERVER }}
         run: |
           cd grpc/clients/python
+          command -v pipenv 1>/dev/null || pip install pipenv
           make test
 
       - name: Coverage with pytest
@@ -83,6 +84,7 @@ jobs:
           WALLET_PASSPHRASE: ${{ secrets.WALLET_PASSPHRASE }}
           WALLETSERVER_URL: ${{ secrets.WALLETSERVER }}
         run: |
+          command -v pipenv 1>/dev/null || pip install pipenv
           cd grpc/examples/python
           make examples_ci
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,7 @@ name: Python
       - main
     paths:
       - "grpc/clients/python/**"
+      - "grpc/examples/python/**"
   push:
     branches:
       - develop
@@ -75,6 +76,18 @@ jobs:
           cd grpc/clients/python
           python3 setup.py sdist bdist_wheel
           make check_dist
+
+      - name: Run example scripts
+        env:
+          NODE_URL_GRPC: ${{ secrets.GRPC_NODE }}
+          PYTHONPATH: ../../clients/python:.
+          WALLET_NAME: ${{ secrets.WALLET_NAME }}
+          WALLET_PASSPHRASE: ${{ secrets.WALLET_PASSPHRASE }}
+          WALLETSERVER_URL: ${{ secrets.WALLETSERVER }}
+        run: |
+          cd grpc/examples/python
+          pipenv sync && pipenv clean
+          pipenv run python3 submit-order.py --ci
 
       - name: Push release to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.8' }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -37,20 +37,20 @@ jobs:
       - name: Lint with flake8
         run: |
           command -v flake8 1>/dev/null || pip install flake8
-          cd grpc/clients/python && make flake8
-          cd grpc/examples/python && make flake8
+          (cd grpc/clients/python && make flake8)
+          (cd grpc/examples/python && make flake8)
 
       - name: Lint with black
         run: |
           command -v black 1>/dev/null || pip install black
-          cd grpc/clients/python && make blackcheck
-          cd grpc/examples/python && make blackcheck
+          (cd grpc/clients/python && make blackcheck)
+          (cd grpc/examples/python && make blackcheck)
 
       - name: Type-check with mypy
         run: |
           command -v mypy 1>/dev/null || pip install mypy
-          cd grpc/clients/python && make mypy
-          cd grpc/examples/python && make mypy
+          (cd grpc/clients/python && make mypy)
+          (cd grpc/examples/python && make mypy)
 
       - name: Test with pytest
         env:
@@ -59,7 +59,6 @@ jobs:
           WALLETSERVER: ${{ secrets.WALLETSERVER }}
         run: |
           cd grpc/clients/python
-          command -v pipenv 1>/dev/null || pip install pipenv
           make test
 
       - name: Coverage with pytest

--- a/.github/workflows/shellscripts.yml
+++ b/.github/workflows/shellscripts.yml
@@ -22,7 +22,7 @@ name: Shell script tests
 
 jobs:
 
-  shellcheck:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -30,3 +30,13 @@ jobs:
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+
+      - name: Run example shell scripts for REST
+        env:
+          NODE_URL_REST: ${{ secrets.NODE_URL_REST }}
+          WALLET_NAME: ${{ secrets.WALLET_NAME }}
+          WALLET_PASSPHRASE: ${{ secrets.WALLET_PASSPHRASE }}
+          WALLETSERVER_URL: ${{ secrets.WALLETSERVER }}
+        run: |
+          cd rest/examples/shell
+          make

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+__pycache__
 *.tmp

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,37 @@ spellcheck:
 	pyspelling -c spellcheck.yaml && \
 	deactivate
 
+# Just for Python
+
+.PHONY: black
+black:
+	@black --exclude generated -l 79 .
+
+.PHONY: blackcheck
+blackcheck:
+	@black --exclude generated -l 79 --check .
+
+.PHONY: flake8
+flake8:
+	@find . -name generated -prune -o -name '*.py' -print | xargs flake8
+
+.PHONY: mypy
+mypy:
+	@echo "Running mypy in grpc/clients/python" ; \
+	( \
+		cd grpc/clients/python && \
+		env MYPYPATH=. mypy --ignore-missing-imports . | grep -vE '(^Found|/generated/|: note: )' ; \
+		code="$$?" ; \
+		test "$$code" -ne 0 \
+	)
+	@for d in grpc/examples/python rest/examples/python ; do \
+		echo "Running mypy in $$d" ; \
+		( \
+			cd "$$d" && \
+			env MYPYPATH=. mypy --ignore-missing-imports . || exit 1 \
+		) || exit 1 ; \
+	done
+
 # Clean
 
 .PHONY: clean

--- a/grpc/clients/python/.gitignore
+++ b/grpc/clients/python/.gitignore
@@ -4,5 +4,4 @@
 /dist
 *.egg-info
 .mypy_cache
-__pycache__
 .pytest_cache

--- a/grpc/clients/python/Makefile
+++ b/grpc/clients/python/Makefile
@@ -10,6 +10,7 @@ default:
 	@echo "- coverage:   make coverage report"
 	@echo "- dist:       build and upload to PyPI"
 	@echo "- dist_test:  build and upload to test-PyPI"
+	@echo "- flake8:     run flake8"
 	@echo "- mypy:       run mypy"
 	@echo "- test:       run pytest"
 	@echo "- clean:      remove the generated dir"

--- a/grpc/clients/python/Makefile
+++ b/grpc/clients/python/Makefile
@@ -5,27 +5,11 @@ GENERATED_DIR := vegaapiclient/generated
 .PHONY: default
 default:
 	@echo "Please select a target:"
-	@echo "- black:      autoformat non-auto-generated py files"
-	@echo "- blackcheck: check non-auto-generated py files"
-	@echo "- coverage:   make coverage report"
+	@echo "- check_dist: check file counts in tgz and whl packages"
 	@echo "- dist:       build and upload to PyPI"
 	@echo "- dist_test:  build and upload to test-PyPI"
-	@echo "- flake8:     run flake8"
-	@echo "- mypy:       run mypy"
 	@echo "- test:       run pytest"
 	@echo "- clean:      remove the generated dir"
-
-.PHONY: black
-black:
-	@black --exclude generated -l 79 vegaapiclient/ tests/
-
-.PHONY: blackcheck
-blackcheck:
-	@black --exclude generated -l 79 --check vegaapiclient/ tests/
-
-.PHONY: coverage
-coverage: | varcheck pipenv_install
-	@pipenv run pytest --cov=vegaapiclient --cov-report=term --cov-report=html:coverage tests/
 
 .PHONY: check_dist
 check_dist:
@@ -51,28 +35,13 @@ dist_test:
 	@python3 setup.py sdist bdist_wheel
 	@echo twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-.PHONY: flake8
-flake8:
-	@find tests/ vegaapiclient/ -name generated -prune -o -name '*.py' -print |xargs flake8
-
-.PHONY: mypy
-mypy:
-	@env MYPYPATH=. mypy --ignore-missing-imports . | grep -vE '(^Found|/generated/|: note: )' ; \
-	code="$$?" ; test "$$code" -ne 0
-
-.PHONY: pipenv_install
-pipenv_install:
-	@pipenv --bare install # 1>/dev/null 2>&1
-
 .PHONY: test
-test: | varcheck pipenv_install
-	@pipenv run pip install -e .
-	@env PYTHONPATH=. pipenv run pytest tests/
-
-.PHONY: varcheck
-varcheck:
+test:
 	@if test -z "$$GRPC_NODE" ; then echo "Please set GRPC_NODE (e.g. node.xx.vega.zzz:1111)." ; exit 1 ; fi
 	@if test -z "$$WALLETSERVER" ; then echo "Please set WALLETSERVER (e.g. https://wallet.xx.vega.zzz)." ; exit 1 ; fi
+	@pipenv --bare install # 1>/dev/null 2>&1
+	@pipenv run pip install -e .
+	@env PYTHONPATH=. pipenv run pytest tests/
 
 .PHONY: clean
 clean:

--- a/grpc/examples/python/Makefile
+++ b/grpc/examples/python/Makefile
@@ -2,31 +2,6 @@
 
 .PHONY: default
 default:
-	@echo "Please select a target:"
-	@echo "- black:       autoformat non-auto-generated py files"
-	@echo "- blackcheck:  check non-auto-generated py files"
-	@echo "- examples_ci: run example python scripts in CI mode"
-	@echo "- flake8:      run flake8"
-	@echo "- mypy:        run mypy"
-
-.PHONY: black
-black:
-	@black -l 79 .
-
-.PHONY: blackcheck
-blackcheck:
-	@black --check .
-
-.PHONY: flake8
-flake8:
-	@flake8 .
-
-.PHONY: mypy
-mypy:
-	@env MYPYPATH=. mypy --ignore-missing-imports .
-
-.PHONY: examples_ci
-examples_ci:
 	@pipenv --bare sync
 	@pipenv --bare clean
 	@env PYTHONPATH=../../clients/python:. pipenv run python3 submit-order.py --ci

--- a/grpc/examples/python/Makefile
+++ b/grpc/examples/python/Makefile
@@ -1,0 +1,32 @@
+# Makefile
+
+.PHONY: default
+default:
+	@echo "Please select a target:"
+	@echo "- black:       autoformat non-auto-generated py files"
+	@echo "- blackcheck:  check non-auto-generated py files"
+	@echo "- examples_ci: run example python scripts in CI mode"
+	@echo "- flake8:      run flake8"
+	@echo "- mypy:        run mypy"
+
+.PHONY: black
+black:
+	@black -l 79 .
+
+.PHONY: blackcheck
+blackcheck:
+	@black --check .
+
+.PHONY: flake8
+flake8:
+	@flake8 .
+
+.PHONY: mypy
+mypy:
+	@env MYPYPATH=. mypy --ignore-missing-imports .
+
+.PHONY: examples_ci
+examples_ci:
+	@pipenv --bare sync
+	@pipenv --bare clean
+	@env PYTHONPATH=../../clients/python:. pipenv run python3 submit-order.py --ci

--- a/grpc/examples/python/Pipfile
+++ b/grpc/examples/python/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+googleapis-common-protos = "==1.52.0"
+grpcio = "==1.33.2"
+requests = "==2.25.1"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/grpc/examples/python/Pipfile.lock
+++ b/grpc/examples/python/Pipfile.lock
@@ -1,0 +1,152 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0163ef64ad24ab38a198b50647145fa5804ae4d2ba502d77d7c476ad6791d760"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "version": "==4.0.0"
+        },
+        "googleapis-common-protos": {
+            "hashes": [
+                "sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351",
+                "sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24"
+            ],
+            "index": "pypi",
+            "version": "==1.52.0"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:02a4a637a774382d6ac8e65c0a7af4f7f4b9704c980a0a9f4f7bbc1e97c5b733",
+                "sha256:08b6a58c8a83e71af5650f8f879fe14b7b84dce0c4969f3817b42c72989dacf0",
+                "sha256:0aeed3558a0eec0b31700af6072f1c90e8fd5701427849e76bc469554a14b4f5",
+                "sha256:0cebba3907441d5c620f7b491a780ed155140fbd590da0886ecfb1df6ad947b9",
+                "sha256:143b4fe72c01000fc0667bf62ace402a6518939b3511b3c2bec04d44b1d7591c",
+                "sha256:21265511880056d19ce4f809ce3fbe2a3fa98ec1fc7167dbdf30a80d3276202e",
+                "sha256:289671cfe441069f617bf23c41b1fa07053a31ff64de918d1016ac73adda2f73",
+                "sha256:2d5124284f9d29e4f06f674a12ebeb23fc16ce0f96f78a80a6036930642ae5ab",
+                "sha256:2f2eabfd514af8945ee415083a0f849eea6cb3af444999453bb6666fadc10f54",
+                "sha256:3ac453387add933b6cfbc67cc8635f91ff9895299130fc612c3c4b904e91d82a",
+                "sha256:407b4d869ce5c6a20af5b96bb885e3ecaf383e3fb008375919eb26cf8f10d9cd",
+                "sha256:4bb771c4c2411196b778871b519c7e12e87f3fa72b0517b22f952c64ead07958",
+                "sha256:4cef3eb2df338abd9b6164427ede961d351c6bf39b4a01448a65f9e795f56575",
+                "sha256:514b4a6790d6597fc95608f49f2f13fe38329b2058538095f0502b734b98ffd2",
+                "sha256:52143467237bfa77331ed1979dc3e203a1c12511ee37b3ddd9ff41b05804fb10",
+                "sha256:56e2a985efdba8e2282e856470b684e83a3cadd920f04fcd360b4b826ced0dd3",
+                "sha256:592656b10528aa327058d2007f7ab175dc9eb3754b289e24cac36e09129a2f6b",
+                "sha256:5b21d3de520a699cb631cfd3a773a57debeb36b131be366bf832153405cc5404",
+                "sha256:62ce7e86f11e8c4ff772e63c282fb5a7904274258be0034adf37aa679cf96ba0",
+                "sha256:65b06fa2db2edd1b779f9b256e270f7a58d60e40121660d8b5fd6e8b88f122ed",
+                "sha256:6a1b5b7e47600edcaeaa42983b1c19e7a5892c6b98bcde32ae2aa509a99e0436",
+                "sha256:703da25278ee7318acb766be1c6d3b67d392920d002b2d0304e7f3431b74f6c1",
+                "sha256:7744468ee48be3265db798f27e66e118c324d7831a34fd39d5775bcd5a70a2c4",
+                "sha256:7c1ea6ea6daa82031af6eb5b7d1ab56b1193840389ea7cf46d80e98636f8aff5",
+                "sha256:7d292dabf7ded9c062357f8207e20e94095a397d487ffd25aa213a2c3dff0ab4",
+                "sha256:7f727b8b6d9f92fcab19dbc62ec956d8352c6767b97b8ab18754b2dfa84d784f",
+                "sha256:7fda62846ef8d86caf06bd1ecfddcae2c7e59479a4ee28808120e170064d36cc",
+                "sha256:85e56ab125b35b1373205b3802f58119e70ffedfe0d7e2821999126058f7c44f",
+                "sha256:88f2a102cbc67e91f42b4323cec13348bf6255b25f80426088079872bd4f3c5c",
+                "sha256:89add4f4cda9546f61cb8a6988bc5b22101dd8ca4af610dff6f28105d1f78695",
+                "sha256:8cf67b8493bff50fa12b4bc30ab40ce1f1f216eb54145962b525852959b0ab3d",
+                "sha256:a8c84db387907e8d800c383e4c92f39996343adedf635ae5206a684f94df8311",
+                "sha256:abaf30d18874310d4439a23a0afb6e4b5709c4266966401de7c4ae345cc810ee",
+                "sha256:affbb739fde390710190e3540acc9f3e65df25bd192cc0aa554f368288ee0ea2",
+                "sha256:b412f43c99ca72769306293ba83811b241d41b62ca8f358e47e0fdaf7b6fbbd7",
+                "sha256:b581ddb8df619402c377c81f186ad7f5e2726ad9f8d57047144b352f83f37522",
+                "sha256:bf7de9e847d2d14a0efcd48b290ee181fdbffb2ae54dfa2ec2a935a093730bac",
+                "sha256:c5030be8a60fb18de1fc8d93d130d57e4296c02f229200df814f6578da00429e",
+                "sha256:c89510381cbf8c8317e14e747a8b53988ad226f0ed240824064a9297b65f921d",
+                "sha256:d386630af995fd4de225d550b6806507ca09f5a650f227fddb29299335cda55e",
+                "sha256:d51ddfb3d481a6a3439db09d4b08447fb9f6b60d862ab301238f37bea8f60a6d",
+                "sha256:dd47fac2878f6102efa211461eb6fa0a6dd7b4899cd1ade6cdcb9fa9748363eb",
+                "sha256:eff55d318a114742ed2a06972f5daacfe3d5ad0c0c0d9146bcaf10acb427e6be",
+                "sha256:f2673c51e8535401c68806d331faba614bcff3ee16373481158a2e74f510b7f6",
+                "sha256:fa78bd55ec652d4a88ba254c8dae623c9992e2ce647bd17ba1a37ca2b7b42222",
+                "sha256:ffec0b854d2ed6ee98776c7168c778cdd18503642a68d36c00ba0f96d4ccff7c"
+            ],
+            "index": "pypi",
+            "version": "==1.33.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "version": "==2.10"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:05c304396e309661c45e3a97bd2d8da1fc2bab743ed2ca880bcb757271c40c0e",
+                "sha256:05dfe9319939a8473c21b469f34f6486646e54fb8542637cf7ed8e2fbfe21538",
+                "sha256:1488f786bd1912f97796cf5def8cacf433735616896cf7ed9dc786cee693dfc8",
+                "sha256:15351df904347da2081a2eebc42b192c29724eb57dbe56dae440be843f1e4779",
+                "sha256:295944ef0772498d7bf75f6aa5d4dfcfd02f5ce70f735b406e52e43ac3914d38",
+                "sha256:2f77afe33bb86c7d34221a86193256d69aa10818620fe4a7513d98211d67d672",
+                "sha256:3237acce5b666c7b0f45785cc2d0809796d4df3593bd68338aebf25408139188",
+                "sha256:3b5c461af5a3cebd796c73370db929b7e24cbaba655eefdc044226bc8a843d6b",
+                "sha256:3d338910b10b88b18581cf6877b3938b2e262e8fdc2c1057f5a291787de63183",
+                "sha256:44399393c3a8cc04a4cfbdc721dd7f2114497efda582e946a91b8c4290ae5ff5",
+                "sha256:4c8d0997fdc0a4cf9de7950d598ce6974b22e8618bbcf1d15e9842010cf8420a",
+                "sha256:5356981c1919782b8c2e3ea5c5d85ad5937b8178a025ac9edc2f2ca5b4a717ae",
+                "sha256:809a96d5a1a74538728710f9104f43ae77f5e48bde274ee321b10a324ba52e4f",
+                "sha256:850f429bd2399525d339d05bc809f090f16d3d88737bed637d355a5ee8d3b81a",
+                "sha256:8a3ac375539055164f31a330770f137875307e6f04c21e2647f2e7139c501295",
+                "sha256:939ce06846ddfec99c0bff510510b3ee45778e7a3aec6544d1f36526e5fecb67",
+                "sha256:9ae321459d4890c3939c536382f75e232c9e91ce506310353c8a15ad5c379e0d",
+                "sha256:a29631f4f8bcf79b12a59e83d238d888de5034871461d788c74c68218ad75049",
+                "sha256:acc9f2091ace3de429eee424ab7ba0bc52a6aa9ffc9909e5c4de259a3f71db46",
+                "sha256:baea44967071e6a51e705e4e88aebf35f530a14004cc69f60a185e5d7e13de7e",
+                "sha256:bcaff977db178f0bfde10bab0d23a5f5adf5964adba70c315e45922a1c55eb90",
+                "sha256:e32ef0c9f4b548c80d94dfff8b4130ca2ff3d50caaf2455889e3f5b8a01e8038",
+                "sha256:eac0a2a7ea99e17175f6e7b53cdc9004ed786c072fbdf933def0e454e14fd323"
+            ],
+            "version": "==3.17.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "index": "pypi",
+            "version": "==2.25.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "version": "==1.16.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+            ],
+            "version": "==1.26.4"
+        }
+    },
+    "develop": {}
+}

--- a/grpc/examples/python/helpers.py
+++ b/grpc/examples/python/helpers.py
@@ -1,0 +1,78 @@
+import random
+import os
+import requests
+import string
+from typing import Any, Optional
+
+
+def check_response(r: requests.Response) -> None:
+    if r.status_code != 200:
+        raise Exception(f"{r.url} returned HTTP {r.status_code} {r.text}")
+
+
+def check_var(val: Optional[str]) -> bool:
+    """
+    Return true if the value is ok.
+    """
+    if missing(val):
+        return False
+    if invalid(val):
+        return False
+    return True
+
+
+def check_url(url: Optional[str]) -> bool:
+    """
+    Return true if the URL is ok.
+    """
+    if not check_var(url):
+        return False
+    if not any(url.startswith(prefix) for prefix in ["http://", "https://"]):
+        return False
+    return True
+
+
+def get_from_env(var_name: str) -> str:
+    """
+    Get a value from an environment variable. Used in CI for testing.
+    """
+    val = os.getenv(var_name)
+    if missing(val):
+        print(f"Error: Missing environment variable {var_name}.")
+        exit(1)
+
+    return val
+
+
+def invalid(val: str) -> bool:
+    bzzt = [">>", "e.g.", "example"]
+    return any(x in val for x in bzzt)
+
+
+def missing(val: Optional[str]) -> bool:
+    """
+    Return true if the value is missing.
+    """
+    return val is None or val == ""
+
+
+def random_string(length: int = 20) -> str:
+    choices = string.ascii_letters + string.digits
+    return "".join(random.choice(choices) for i in range(length))
+
+
+def fix_walletserver_url(url: str) -> str:
+    for suffix in ["/api/v1/", "/api/v1", "/api/", "/api", "/"]:
+        if not url.endswith(suffix):
+            continue
+        print(
+            f'There\'s no need to add "{suffix}" to the wallet server URL. '
+            "Removing it and continuing..."
+        )
+        url = url[: -len(suffix)]
+
+    return url
+
+
+def enum_to_str(e: Any, val: int) -> str:
+    return e.keys()[e.values().index(val)]

--- a/grpc/examples/python/helpers.py
+++ b/grpc/examples/python/helpers.py
@@ -2,7 +2,7 @@ import random
 import os
 import requests
 import string
-from typing import Any, Optional
+from typing import Any
 
 
 def check_response(r: requests.Response) -> None:
@@ -13,18 +13,18 @@ def check_response(r: requests.Response) -> None:
         raise Exception(f"{r.url} returned HTTP {r.status_code} {r.text}")
 
 
-def check_var(val: Optional[str]) -> bool:
+def check_var(val: str) -> bool:
     """
     Return true if the value is ok.
     """
-    if missing(val):
+    if val == "":
         return False
     if invalid(val):
         return False
     return True
 
 
-def check_url(url: Optional[str]) -> bool:
+def check_url(url: str) -> bool:
     """
     Return true if the URL is ok.
     """
@@ -39,8 +39,8 @@ def get_from_env(var_name: str) -> str:
     """
     Get a value from an environment variable. Used in CI for testing.
     """
-    val = os.getenv(var_name)
-    if missing(val):
+    val = os.getenv(var_name, "")
+    if val == "":
         print(f"Error: Missing environment variable {var_name}.")
         exit(1)
 
@@ -53,13 +53,6 @@ def invalid(val: str) -> bool:
     """
     bzzt = [">>", "e.g.", "example"]
     return any(x in val for x in bzzt)
-
-
-def missing(val: Optional[str]) -> bool:
-    """
-    Return true if the value is missing.
-    """
-    return val is None or val == ""
 
 
 def random_string(length: int = 20) -> str:

--- a/grpc/examples/python/helpers.py
+++ b/grpc/examples/python/helpers.py
@@ -6,6 +6,9 @@ from typing import Any, Optional
 
 
 def check_response(r: requests.Response) -> None:
+    """
+    Raise a helpful exception if the HTTP response was not 200.
+    """
     if r.status_code != 200:
         raise Exception(f"{r.url} returned HTTP {r.status_code} {r.text}")
 
@@ -45,6 +48,9 @@ def get_from_env(var_name: str) -> str:
 
 
 def invalid(val: str) -> bool:
+    """
+    Return true if none of the invalid strings are found in the value.
+    """
     bzzt = [">>", "e.g.", "example"]
     return any(x in val for x in bzzt)
 
@@ -57,11 +63,17 @@ def missing(val: Optional[str]) -> bool:
 
 
 def random_string(length: int = 20) -> str:
+    """
+    Generate a random string, made of letters and digits.
+    """
     choices = string.ascii_letters + string.digits
     return "".join(random.choice(choices) for i in range(length))
 
 
 def fix_walletserver_url(url: str) -> str:
+    """
+    Help guide users against including api version suffix in wallet server URL.
+    """
     for suffix in ["/api/v1/", "/api/v1", "/api/", "/api", "/"]:
         if not url.endswith(suffix):
             continue

--- a/grpc/examples/python/submit-order.py
+++ b/grpc/examples/python/submit-order.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+"""
+Script language: Python3
+
+Talks to:
+- Vega wallet (REST)
+- Vega node (gRPC)
+
+Apps/Libraries:
+- REST (wallet): Vega-API-client (https://pypi.org/project/Vega-API-client/)
+- gRPC (node): Vega-API-client (https://pypi.org/project/Vega-API-client/)
+"""
+
+# Note: this file uses special tags in comments to enable snippets to be
+# included in documentation.
+# Example
+#   #  __something:
+#   some code here
+#   # :something__
+
+import base64
+import grpc
+import json
+import sys
+
+# __import_client:
+import vegaapiclient as vac
+
+# :import_client__
+
+import helpers
+
+# --- Edit these values below ---
+node_url_grpc = ">> e.g. n06.testnet.vega.xyz:3002"
+walletserver_url = ">> Vega-hosted wallet: https://wallet.testnet.vega.xyz"
+walletserver_url = ">> self-hosted wallet: http://localhost:1789"
+wallet_name = ">> your wallet name here"
+wallet_passphrase = ">> your passphrase here"
+# --- Edit these values above ---
+
+placeholder_marker = ">>"
+
+if "--ci" in sys.argv:
+    node_url_grpc = helpers.get_from_env("NODE_URL_GRPC")
+    walletserver_url = helpers.get_from_env("WALLETSERVER_URL")
+    wallet_name = helpers.get_from_env("WALLET_NAME")
+    wallet_passphrase = helpers.get_from_env("WALLET_PASSPHRASE")
+
+if not helpers.check_var(node_url_grpc):
+    print("Invalid Vega node URL (gRPC)")
+    exit(1)
+
+if not helpers.check_url(walletserver_url):
+    print("Invalid wallet server URL")
+    exit(1)
+
+if not helpers.check_var(wallet_name):
+    print("Invalid wallet name")
+    exit(1)
+
+if not helpers.check_var(wallet_passphrase):
+    print("Invalid wallet passphrase")
+    exit(1)
+
+
+# Help guide users against including api version suffix on url
+walletserver_url = helpers.fix_walletserver_url(walletserver_url)
+
+# __create_wallet:
+# Vega node: Create client for accessing public data
+datacli = vac.VegaTradingDataClient(node_url_grpc)
+
+# Vega node: Create client for trading (e.g. submitting orders)
+tradingcli = vac.VegaTradingClient(node_url_grpc)
+
+# Wallet server: Create a walletclient (see above for details)
+walletclient = vac.WalletClient(walletserver_url)
+login_response = walletclient.login(wallet_name, wallet_passphrase)
+# :create_wallet__
+helpers.check_response(login_response)
+
+# __get_market:
+# Get a list of markets
+markets = datacli.Markets(vac.api.trading.MarketsRequest()).markets
+marketID = markets[0].id
+# :get_market__
+
+# __generate_keypair:
+GENERATE_NEW_KEYPAIR = False
+if GENERATE_NEW_KEYPAIR:
+    # If you don't already have a keypair, generate one.
+    response = walletclient.generatekey(wallet_passphrase, [])
+    helpers.check_response(response)
+    pubKey = response.json()["key"]["pub"]
+else:
+    # List keypairs
+    response = walletclient.listkeys()
+    helpers.check_response(response)
+    keys = response.json()["keys"]
+    assert len(keys) > 0
+    pubKey = keys[0]["pub"]
+# :generate_keypair__
+
+# __prepare_order:
+# Vega node: Prepare the SubmitOrder
+order = vac.api.trading.PrepareSubmitOrderRequest(
+    submission=vac.commands.v1.commands.OrderSubmission(
+        market_id=marketID,
+        # price is an integer. For example 123456 is a price of 1.23456,
+        # assuming 5 decimal places.
+        price=100000,
+        side=vac.vega.Side.SIDE_BUY,
+        size=1,
+        time_in_force=vac.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+        type=vac.vega.Order.Type.TYPE_LIMIT,
+    )
+)
+print(f"Request for PrepareSubmitOrder: {order}")
+try:
+    prepare_response = tradingcli.PrepareSubmitOrder(order)
+except grpc.RpcError as exc:
+    print(json.dumps(vac.grpc_error_detail(exc), indent=2, sort_keys=True))
+    exit(1)
+print(f"Response from PrepareSubmitOrder: {prepare_response}")
+# :prepare_order__
+
+# __sign_tx:
+# Wallet server: Sign the prepared transaction
+blob_base64 = base64.b64encode(prepare_response.blob).decode("ascii")
+print(f"Request for SignTx: blob={blob_base64}, pubKey={pubKey}")
+response = walletclient.signtx(blob_base64, pubKey, False)
+helpers.check_response(response)
+responsejson = response.json()
+print("Response from SignTx:")
+print(json.dumps(responsejson, indent=2, sort_keys=True))
+signedTx = responsejson["signedTx"]
+# :sign_tx__
+
+# __submit_tx:
+# Vega node: Submit the signed transaction
+request = vac.api.trading.SubmitTransactionRequest(
+    tx=vac.vega.SignedBundle(
+        tx=base64.b64decode(signedTx["tx"]),
+        sig=vac.vega.Signature(
+            sig=base64.b64decode(signedTx["sig"]["sig"]),
+            algo="vega/ed25519",
+            version=1,
+        ),
+    ),
+)
+print(f"Request for SubmitTransaction: {request}")
+submittx_response = tradingcli.SubmitTransaction(request)
+# :submit_tx__
+assert submittx_response.success
+print("All is well.")

--- a/grpc/examples/python/submit-order.py
+++ b/grpc/examples/python/submit-order.py
@@ -26,6 +26,7 @@ import sys
 
 # __import_client:
 import vegaapiclient as vac
+
 # :import_client__
 import helpers
 

--- a/grpc/examples/python/submit-order.py
+++ b/grpc/examples/python/submit-order.py
@@ -26,9 +26,7 @@ import sys
 
 # __import_client:
 import vegaapiclient as vac
-
 # :import_client__
-
 import helpers
 
 # --- Edit these values below ---
@@ -39,8 +37,6 @@ wallet_name = ">> your wallet name here"
 wallet_passphrase = ">> your passphrase here"
 # --- Edit these values above ---
 
-placeholder_marker = ">>"
-
 if "--ci" in sys.argv:
     node_url_grpc = helpers.get_from_env("NODE_URL_GRPC")
     walletserver_url = helpers.get_from_env("WALLETSERVER_URL")
@@ -49,20 +45,23 @@ if "--ci" in sys.argv:
 
 if not helpers.check_var(node_url_grpc):
     print("Invalid Vega node URL (gRPC)")
+    print('Edit this script and look for "Edit these values"')
     exit(1)
 
 if not helpers.check_url(walletserver_url):
     print("Invalid wallet server URL")
+    print('Edit this script and look for "Edit these values"')
     exit(1)
 
 if not helpers.check_var(wallet_name):
     print("Invalid wallet name")
+    print('Edit this script and look for "Edit these values"')
     exit(1)
 
 if not helpers.check_var(wallet_passphrase):
     print("Invalid wallet passphrase")
+    print('Edit this script and look for "Edit these values"')
     exit(1)
-
 
 # Help guide users against including api version suffix on url
 walletserver_url = helpers.fix_walletserver_url(walletserver_url)
@@ -83,6 +82,7 @@ helpers.check_response(login_response)
 # __get_market:
 # Get a list of markets
 markets = datacli.Markets(vac.api.trading.MarketsRequest()).markets
+# Choose the first.
 marketID = markets[0].id
 # :get_market__
 

--- a/grpc/examples/shell/helpers.sh
+++ b/grpc/examples/shell/helpers.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+check_var() {
+	var_name="${1:?}"
+	var_value="${!var_name}"
+	if [[ -z "$var_value" ]] ; then
+		echo "Invalid $var_name - empty"
+		return 1
+	fi
+}
+
+check_url() {
+	var_name="${1:?}"
+	check_var "$var_name" || return 1
+	invalid "$var_name" && return 1
+	var_value="${!var_name}"
+	if ! echo "$var_value" | grep -qE '^http[s]?://' ; then
+		echo "Invalid $var_name - does not start with \"http://\" or \"https://\""
+		return 1
+	fi
+}
+
+invalid() {
+	var_name="${1:?}"
+	var_value="${!var_name}"
+	for substr in ">>" "e.g." "example" ; do
+		if echo "$var_value" | grep -qF "$substr" ; then
+			echo "Invalid $var_name - contains \"$substr\""
+			return 0
+		fi
+	done
+	return 1
+}

--- a/rest/examples/python/Makefile
+++ b/rest/examples/python/Makefile
@@ -1,0 +1,7 @@
+# Makefile
+
+.PHONY: default
+default:
+	@pipenv --bare sync
+	@pipenv --bare clean
+	@env PYTHONPATH=../../../grpc/examples/python:. pipenv run python3 submit-order.py --ci

--- a/rest/examples/python/Pipfile
+++ b/rest/examples/python/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/rest/examples/python/Pipfile.lock
+++ b/rest/examples/python/Pipfile.lock
@@ -1,0 +1,57 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d927fcadfe1cb7a3936766a19e9ff3dd822eca2b5d080bb479058a806e4fe234"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "version": "==4.0.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "version": "==2.10"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "index": "pypi",
+            "version": "==2.25.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+            ],
+            "version": "==1.26.4"
+        }
+    },
+    "develop": {}
+}

--- a/rest/examples/python/submit-order.py
+++ b/rest/examples/python/submit-order.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+"""
+Script language: Python3
+
+Talks to:
+- Vega wallet (REST)
+- Vega node (REST)
+
+Apps/Libraries:
+- REST (wallet): requests (https://pypi.org/project/requests/)
+- REST (node): requests (https://pypi.org/project/requests/)
+"""
+
+# Note: this file uses special tags in comments to enable snippets to be
+# included in documentation.
+# Example
+#   #  __something:
+#   some code here
+#   # :something__
+
+import json
+import requests
+import sys
+from typing import Any, Dict
+
+import helpers
+
+# --- Edit these values below ---
+node_url_rest = ">> e.g. https://lb.testnet.vega.xyz"
+walletserver_url = ">> Vega-hosted wallet: https://wallet.testnet.vega.xyz"
+walletserver_url = ">> self-hosted wallet: http://localhost:1789"
+wallet_name = ">> your wallet name here"
+wallet_passphrase = ">> your passphrase here"
+# --- Edit these values above ---
+
+if "--ci" in sys.argv:
+    node_url_rest = helpers.get_from_env("NODE_URL_REST")
+    walletserver_url = helpers.get_from_env("WALLETSERVER_URL")
+    wallet_name = helpers.get_from_env("WALLET_NAME")
+    wallet_passphrase = helpers.get_from_env("WALLET_PASSPHRASE")
+
+if not helpers.check_url(node_url_rest):
+    print("Invalid Vega node URL (REST)")
+    print('Edit this script and look for "Edit these values"')
+    exit(1)
+
+if not helpers.check_url(walletserver_url):
+    print("Invalid wallet server URL")
+    print('Edit this script and look for "Edit these values"')
+    exit(1)
+
+if not helpers.check_var(wallet_name):
+    print("Invalid wallet name")
+    print('Edit this script and look for "Edit these values"')
+    exit(1)
+
+if not helpers.check_var(wallet_passphrase):
+    print("Invalid wallet passphrase")
+    print('Edit this script and look for "Edit these values"')
+    exit(1)
+
+# Help guide users against including api version suffix on url
+walletserver_url = helpers.fix_walletserver_url(walletserver_url)
+
+# __create_wallet:
+CREATE_NEW_WALLET = False
+if CREATE_NEW_WALLET:
+    # EITHER: Create new wallet
+    url = f"{walletserver_url}/api/v1/wallets"
+else:
+    # OR: Log in to existing wallet
+    url = f"{walletserver_url}/api/v1/auth/token"
+
+req: Dict[str, Any]
+
+# Make request to create new wallet or log in to existing wallet
+req = {"wallet": wallet_name, "passphrase": wallet_passphrase}
+response = requests.post(url, json=req)
+helpers.check_response(response)
+
+# Pull out the token and make a headers dict
+token = response.json()["token"]
+headers = {"Authorization": f"Bearer {token}"}
+# :create_wallet__
+
+# __generate_keypair:
+GENERATE_NEW_KEYPAIR = False
+pubKey = ""
+if GENERATE_NEW_KEYPAIR:
+    # EITHER: Generate a new keypair
+    req = {
+        "passphrase": wallet_passphrase,
+        "meta": [{"key": "alias", "value": "my_key_alias"}],
+    }
+    url = f"{walletserver_url}/api/v1/keys"
+    response = requests.post(url, headers=headers, json=req)
+    helpers.check_response(response)
+    pubKey = response.json()["key"]["pub"]
+else:
+    # OR: List existing keypairs
+    url = f"{walletserver_url}/api/v1/keys"
+    response = requests.get(url, headers=headers)
+    helpers.check_response(response)
+    keys = response.json()["keys"]
+    assert len(keys) > 0
+    pubKey = keys[0]["pub"]
+# :generate_keypair__
+
+assert pubKey != ""
+
+# __get_market:
+# Next, get a Market ID
+url = f"{node_url_rest}/markets"
+response = requests.get(url)
+helpers.check_response(response)
+marketID = response.json()["markets"][0]["id"]
+# :get_market__
+
+# __prepare_order:
+# Next, prepare a SubmitOrder
+response = requests.get(f"{node_url_rest}/time")
+helpers.check_response(response)
+blockchaintime = int(response.json()["timestamp"])
+expiresAt = str(int(blockchaintime + 120 * 1e9))  # expire in 2 minutes
+
+req = {
+    "submission": {
+        "marketId": marketID,
+        "partyId": pubKey,
+        "price": "100000",  # Note: price is an integer. For example 123456
+        "size": "100",  # is a price of 1.23456, assuming 5 decimal places.
+        "side": "SIDE_BUY",
+        "timeInForce": "TIME_IN_FORCE_GTT",
+        "expiresAt": expiresAt,
+        "type": "TYPE_LIMIT",
+    }
+}
+print("Request for PrepareSubmitOrder:")
+print(json.dumps(req, indent=2, sort_keys=True))
+url = f"{node_url_rest}/orders/prepare/submit"
+response = requests.post(url, json=req)
+helpers.check_response(response)
+preparedOrder = response.json()
+# :prepare_order__
+print("Response from PrepareSubmitOrder:")
+print(json.dumps(preparedOrder, indent=2, sort_keys=True))
+
+# __sign_tx:
+# Wallet server: Sign the prepared transaction
+blob = preparedOrder["blob"]
+req = {"tx": blob, "pubKey": pubKey, "propagate": False}
+print("Request for SignTx:")
+print(json.dumps(req, indent=2, sort_keys=True))
+url = f"{walletserver_url}/api/v1/messages/sync"
+response = requests.post(url, headers=headers, json=req)
+helpers.check_response(response)
+signedTx = response.json()["signedTx"]
+# :sign_tx__
+print("Response from SignTx:")
+print(json.dumps(signedTx, indent=2, sort_keys=True))
+
+# __submit_tx:
+# Vega node: Submit the signed transaction
+req = {"tx": signedTx}
+print("Request for SubmitTransaction:")
+print(json.dumps(req, indent=2, sort_keys=True))
+url = f"{node_url_rest}/transaction"
+response = requests.post(url, json=req)
+helpers.check_response(response)
+# :submit_tx__
+
+assert response.json()["success"]
+print("All is well.")

--- a/rest/examples/shell/Makefile
+++ b/rest/examples/shell/Makefile
@@ -1,0 +1,5 @@
+# Makefile
+
+.PHONY: default
+default:
+	@./submit-order.sh --ci

--- a/rest/examples/shell/submit-order.sh
+++ b/rest/examples/shell/submit-order.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+# Script language: bash
+#
+# Talks to:
+# - Vega wallet (REST)
+# - Vega node (REST)
+#
+# Apps/Libraries:
+# - REST: curl
+
+# Note: this file uses special tags in comments to enable snippets to be
+# included in documentation.
+# Example
+#   #  __something:
+#   some code here
+#   # :something__
+
+source ../../../grpc/examples/shell/helpers.sh
+
+# --- Edit these values below ---
+node_url_rest=">> e.g. n06.testnet.vega.xyz:3002"
+walletserver_url=">> Vega-hosted wallet: https://wallet.testnet.vega.xyz"
+walletserver_url=">> self-hosted wallet: http://localhost:1789"
+wallet_name=">> your wallet name here"
+wallet_passphrase=">> your passphrase here"
+# --- Edit these values above ---
+
+ci=no
+while true ; do
+	case "${1:-}" in
+	--ci) ci=yes ; shift ;;
+	*)
+		[[ -z "$1" ]] && break
+		echo "Unrecognised argument: $1"
+		exit 1
+		;;
+	esac
+done
+
+if [[ "$ci" = yes ]] ; then
+	node_url_rest="${NODE_URL_REST:?}"
+	walletserver_url="${WALLETSERVER_URL:?}"
+	wallet_name="${WALLET_NAME:?}"
+	wallet_passphrase="${WALLET_PASSPHRASE:?}"
+fi
+
+check_url "node_url_rest" || exit 1
+check_url "walletserver_url" || exit 1
+check_var "wallet_name" || exit 1
+check_var "wallet_passphrase" || exit 1
+
+# __create_wallet:
+CREATE_NEW_WALLET=no
+if test "$CREATE_NEW_WALLET" == yes ; then
+	### EITHER: Create new wallet ###
+	url="$walletserver_url/api/v1/wallets"
+else
+	### OR: Log in to existing wallet ###
+	url="$walletserver_url/api/v1/auth/token"
+fi
+
+# Make request to create new wallet or log in to existing wallet
+req='{"wallet": "'"$wallet_name"'","passphrase": "'"$wallet_passphrase"'"}'
+response="$(curl -s -XPOST -d "$req" "$url")"
+
+### Pull out the token and make a headers var ###
+token="$(echo "$response" | jq -r .token)"
+test "$token" == null && exit 1
+hdr="Authorization: Bearer $token"
+# :create_wallet__
+
+cleanup() {
+    rm -f req.json
+}
+trap cleanup EXIT SIGINT
+
+# __generate_keypair:
+GENERATE_NEW_KEYPAIR=no
+pubKey=""
+if test "$GENERATE_NEW_KEYPAIR" == yes ; then
+	### EITHER: Generate a new keypair ###
+	req='{"passphrase":"'"$wallet_passphrase"'","meta":[{"key":"alias","value":"my_key_alias"}]}'
+	url="$walletserver_url/api/v1/keys"
+	response="$(curl -s -XPOST -H "$hdr" -d "$req" "$url")"
+	pubKey="$(echo "$response" | jq -r .key.pub)"
+else
+	### OR: List existing keypairs ###
+	url="$walletserver_url/api/v1/keys"
+	response="$(curl -s -XGET -H "$hdr" "$url")"
+	pubKey="$(echo "$response" | jq -r '.keys[0].pub')"
+fi
+# :generate_keypair__
+
+test -n "$pubKey" || exit 1
+test "$pubKey" == null && exit 1
+
+# __get_market:
+### Next, get a Market ID ###
+url="$node_url_rest/markets"
+echo "get market ID url: $url"
+response="$(curl -s "$url")"
+marketID="$(echo "$response" | jq -r '.markets[0].id')"
+# :get_market__
+
+# __prepare_order:
+### Next, prepare a SubmitOrder ###
+
+# Note: price is an integer. For example 123456 is a price of 1.23456,
+# assuming 5 decimal places.
+
+url="$node_url_rest/time"
+response="$(curl -s "$url")"
+blockchaintime="$(echo "$response" | jq -r .timestamp)"
+expiresAt="$((blockchaintime+120*10**9))" # expire in 2 minutes
+cat >req.json <<EOF
+{
+    "submission": {
+        "marketId": "$marketID",
+        "price": "100000",
+        "size": "100",
+        "side": "SIDE_BUY",
+        "timeInForce": "TIME_IN_FORCE_GTT",
+        "expiresAt": "$expiresAt",
+        "type": "TYPE_LIMIT"
+    }
+}
+EOF
+echo "Request for PrepareSubmitOrder: $(cat req.json)"
+url="$node_url_rest/orders/prepare/submit"
+response="$(curl -s -XPOST -d @req.json "$url")"
+echo "Response from PrepareSubmitOrder: $response"
+# :prepare_order__
+
+# __sign_tx:
+### Wallet server: Sign the prepared transaction ###
+blob="$(echo "$response" | jq -r .blob)"
+test "$blob" == null && exit 1
+cat >req.json <<EOF
+{
+    "tx": "$blob",
+    "pubKey": "$pubKey",
+    "propagate": false
+}
+EOF
+echo "Request for SignTx: $(cat req.json)"
+url="$walletserver_url/api/v1/messages/sync"
+response="$(curl -s -XPOST -H "$hdr" -d @req.json "$url")"
+signedTx="$(echo "$response" | jq .signedTx)"
+echo "Response from SignTx: $signedTx"
+# :sign_tx__
+test "$signedTx" == null && exit 1
+
+# __submit_tx:
+### Vega node: Submit the signed transaction ###
+cat >req.json <<EOF
+{
+    "tx": $signedTx
+}
+EOF
+echo "Request for SubmitTransaction: $(cat req.json)"
+url="$node_url_rest/transaction"
+response="$(curl -s -XPOST -d @req.json "$url")"
+# :submit_tx__
+
+if ! echo "$response" | jq -r .success | grep -q '^true$' ; then
+	echo "Failed"
+	exit 1
+fi
+echo "All is well."

--- a/rest/examples/shell/submit-order.sh
+++ b/rest/examples/shell/submit-order.sh
@@ -16,6 +16,7 @@
 #   some code here
 #   # :something__
 
+# shellcheck disable=SC1091
 source ../../../grpc/examples/shell/helpers.sh
 
 # --- Edit these values below ---


### PR DESCRIPTION
This PR adds:
- 3 submit-order scripts (bash+curl, python+requests, python+Vega-API-client), taken from https://github.com/vegaprotocol/sample-api-scripts/tree/master/submit-order/
- 2 helper scripts (bash, python), taken from https://github.com/vegaprotocol/sample-api-scripts/tree/master/
- `Pipfile` and `Pipfile.lock` taken  from the same place
- CI for running the example scripts

## For readers of example scripts
```python
# --- Edit these values below ---
node_url_grpc = ">> e.g. n06.testnet.vega.xyz:3002"
walletserver_url = ">> Vega-hosted wallet: https://wallet.testnet.vega.xyz"
walletserver_url = ">> self-hosted wallet: http://localhost:1789"
wallet_name = ">> your wallet name here"
wallet_passphrase = ">> your passphrase here"
# --- Edit these values above ---
```

## For CI
```python
if "--ci" in sys.argv:
    node_url_grpc = helpers.get_from_env("NODE_URL_GRPC")
    walletserver_url = helpers.get_from_env("WALLETSERVER_URL")
    wallet_name = helpers.get_from_env("WALLET_NAME")
    wallet_passphrase = helpers.get_from_env("WALLET_PASSPHRASE")
```