### PR TITLE
Add proto doc in json format

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -14,6 +14,11 @@ plugins:
     opt: markdown,index.md
     strategy: all
 
+  - name: doc
+    out: grpc/doc
+    opt: json,doc.json
+    strategy: all
+
   # C++
   - name: cpp
     out: grpc/clients/cpp/generated

--- a/grpc/doc/doc.json
+++ b/grpc/doc/doc.json
@@ -1,0 +1,17105 @@
+{
+  "files": [
+    {
+      "name": "github.com/mwitkow/go-proto-validators/validator.proto",
+      "description": "",
+      "package": "validator",
+      "hasEnums": false,
+      "hasExtensions": true,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [
+        {
+          "name": "field",
+          "longName": ".google.protobuf.FieldOptions.field",
+          "fullName": ".google.protobuf.FieldOptions.field",
+          "description": "",
+          "label": "optional",
+          "type": "FieldValidator",
+          "longType": "FieldValidator",
+          "fullType": "validator.FieldValidator",
+          "number": 65020,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        },
+        {
+          "name": "oneof",
+          "longName": ".google.protobuf.OneofOptions.oneof",
+          "fullName": ".google.protobuf.OneofOptions.oneof",
+          "description": "",
+          "label": "optional",
+          "type": "OneofValidator",
+          "longType": "OneofValidator",
+          "fullType": "validator.OneofValidator",
+          "number": 65021,
+          "defaultValue": "",
+          "containingType": "OneofOptions",
+          "containingLongType": ".google.protobuf.OneofOptions",
+          "containingFullType": "google.protobuf.OneofOptions"
+        }
+      ],
+      "messages": [
+        {
+          "name": "FieldValidator",
+          "longName": "FieldValidator",
+          "fullName": "validator.FieldValidator",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "regex",
+              "description": "Uses a Golang RE2-syntax regex to match the field contents.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "int_gt",
+              "description": "Field value of integer strictly greater than this value.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "int_lt",
+              "description": "Field value of integer strictly smaller than this value.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "msg_exists",
+              "description": "Used for nested message types, requires that the message type exists.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "human_error",
+              "description": "Human error specifies a user-customizable error that is visible to the user.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float_gt",
+              "description": "Field value of double strictly greater than this value.\nNote that this value can only take on a valid floating point\nvalue. Use together with float_epsilon if you need something more specific.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float_lt",
+              "description": "Field value of double strictly smaller than this value.\nNote that this value can only take on a valid floating point\nvalue. Use together with float_epsilon if you need something more specific.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float_epsilon",
+              "description": "Field value of double describing the epsilon within which\nany comparison should be considered to be true. For example,\nwhen using float_gt = 0.35, using a float_epsilon of 0.05\nwould mean that any value above 0.30 is acceptable. It can be\nthought of as a {float_value_condition} +- {float_epsilon}.\nIf unset, no correction for floating point inaccuracies in\ncomparisons will be attempted.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float_gte",
+              "description": "Floating-point value compared to which the field content should be greater or equal.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "float_lte",
+              "description": "Floating-point value compared to which the field content should be smaller or equal.",
+              "label": "optional",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "string_not_empty",
+              "description": "Used for string fields, requires the string to be not empty (i.e different from \"\").",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repeated_count_min",
+              "description": "Repeated field with at least this number of elements.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "repeated_count_max",
+              "description": "Repeated field with at most this number of elements.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "length_gt",
+              "description": "Field value of length greater than this value.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "length_lt",
+              "description": "Field value of length smaller than this value.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "length_eq",
+              "description": "Field value of integer strictly equal this value.",
+              "label": "optional",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "is_in_enum",
+              "description": "Requires that the value is in the enum.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "uuid_ver",
+              "description": "Ensures that a string value is in UUID format.\nuuid_ver specifies the valid UUID versions. Valid values are: 0-5.\nIf uuid_ver is 0 all UUID versions are accepted.",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OneofValidator",
+          "longName": "OneofValidator",
+          "fullName": "validator.OneofValidator",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "required",
+              "description": "Require that one of the oneof fields is set.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "oracles/v1/oracle_spec.proto",
+      "description": "",
+      "package": "oracles.v1",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "Operator",
+          "longName": "Condition.Operator",
+          "fullName": "oracles.v1.Condition.Operator",
+          "description": "Comparator describes the type of comparison.",
+          "values": [
+            {
+              "name": "OPERATOR_UNSPECIFIED",
+              "number": "0",
+              "description": "The default value"
+            },
+            {
+              "name": "OPERATOR_EQUALS",
+              "number": "1",
+              "description": "Verify if the property values are strictly equal or not."
+            },
+            {
+              "name": "OPERATOR_GREATER_THAN",
+              "number": "2",
+              "description": "Verify if the oracle data value is greater than the Condition value."
+            },
+            {
+              "name": "OPERATOR_GREATER_THAN_OR_EQUAL",
+              "number": "3",
+              "description": "Verify if the oracle data value is greater than or equal to the Condition\nvalue."
+            },
+            {
+              "name": "OPERATOR_LESS_THAN",
+              "number": "4",
+              "description": "Verify if the oracle data value is less than the Condition value."
+            },
+            {
+              "name": "OPERATOR_LESS_THAN_OR_EQUAL",
+              "number": "5",
+              "description": "Verify if the oracle data value is less or equal to than the Condition\nvalue."
+            }
+          ]
+        },
+        {
+          "name": "Status",
+          "longName": "OracleSpec.Status",
+          "fullName": "oracles.v1.OracleSpec.Status",
+          "description": "Status describe the status of the oracle spec",
+          "values": [
+            {
+              "name": "STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "The default value."
+            },
+            {
+              "name": "STATUS_ACTIVE",
+              "number": "1",
+              "description": "STATUS_ACTIVE describes an active oracle spec."
+            },
+            {
+              "name": "STATUS_DEACTIVATED",
+              "number": "2",
+              "description": "STATUS_DEACTIVATED describes an oracle spec that is not listening to data\nanymore."
+            }
+          ]
+        },
+        {
+          "name": "Type",
+          "longName": "PropertyKey.Type",
+          "fullName": "oracles.v1.PropertyKey.Type",
+          "description": "Type describes the type of properties that are supported by the oracle\nengine.",
+          "values": [
+            {
+              "name": "TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "The default value."
+            },
+            {
+              "name": "TYPE_EMPTY",
+              "number": "1",
+              "description": "Any type."
+            },
+            {
+              "name": "TYPE_INTEGER",
+              "number": "2",
+              "description": "Integer type."
+            },
+            {
+              "name": "TYPE_STRING",
+              "number": "3",
+              "description": "String type."
+            },
+            {
+              "name": "TYPE_BOOLEAN",
+              "number": "4",
+              "description": "Boolean type."
+            },
+            {
+              "name": "TYPE_DECIMAL",
+              "number": "5",
+              "description": "Any floating point decimal type."
+            },
+            {
+              "name": "TYPE_TIMESTAMP",
+              "number": "6",
+              "description": "Timestamp date type."
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Condition",
+          "longName": "Condition",
+          "fullName": "oracles.v1.Condition",
+          "description": "Condition describes the condition that must be validated by the",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "operator",
+              "description": "comparator is the type of comparison to make on the value.",
+              "label": "",
+              "type": "Operator",
+              "longType": "Condition.Operator",
+              "fullType": "oracles.v1.Condition.Operator",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "value is used by the comparator.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Filter",
+          "longName": "Filter",
+          "fullName": "oracles.v1.Filter",
+          "description": "Filter describes the conditions under which an oracle data is considered of\ninterest or not.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "key is the oracle data property key targeted by the filter.",
+              "label": "",
+              "type": "PropertyKey",
+              "longType": "PropertyKey",
+              "fullType": "oracles.v1.PropertyKey",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "conditions",
+              "description": "conditions are the conditions that should be matched by the data to be\nconsidered of interest.",
+              "label": "repeated",
+              "type": "Condition",
+              "longType": "Condition",
+              "fullType": "oracles.v1.Condition",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleSpec",
+          "longName": "OracleSpec",
+          "fullName": "oracles.v1.OracleSpec",
+          "description": "An oracle spec describe the oracle data that a product (or a risk model)\nwants to get from the oracle engine.\nThis message contains additional information used by the API.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "id is a hash generated from the OracleSpec data.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "Creation Date time",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "updated_at",
+              "description": "Last Updated timestamp",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pub_keys",
+              "description": "pubKeys is the list of authorized public keys that signed the data for this\noracle. All the public keys in the oracle data should be contained in these\npublic keys.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "filters",
+              "description": "filters describes which oracle data are considered of interest or not for\nthe product (or the risk model).",
+              "label": "repeated",
+              "type": "Filter",
+              "longType": "Filter",
+              "fullType": "oracles.v1.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "status describes the status of the oracle spec",
+              "label": "",
+              "type": "Status",
+              "longType": "OracleSpec.Status",
+              "fullType": "oracles.v1.OracleSpec.Status",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleSpecConfiguration",
+          "longName": "OracleSpecConfiguration",
+          "fullName": "oracles.v1.OracleSpecConfiguration",
+          "description": "An oracle spec describe the oracle data that a product (or a risk model)\nwants to get from the oracle engine.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_keys",
+              "description": "pubKeys is the list of authorized public keys that signed the data for this\noracle. All the public keys in the oracle data should be contained in these\npublic keys.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "filters",
+              "description": "filters describes which oracle data are considered of interest or not for\nthe product (or the risk model).",
+              "label": "repeated",
+              "type": "Filter",
+              "longType": "Filter",
+              "fullType": "oracles.v1.Filter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PropertyKey",
+          "longName": "PropertyKey",
+          "fullName": "oracles.v1.PropertyKey",
+          "description": "PropertyKey describes the property key contained in an oracle data.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "name is the name of the property.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "type is the type of the property.",
+              "label": "",
+              "type": "Type",
+              "longType": "PropertyKey.Type",
+              "fullType": "oracles.v1.PropertyKey.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "markets.proto",
+      "description": "",
+      "package": "vega",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "State",
+          "longName": "Market.State",
+          "fullName": "vega.Market.State",
+          "description": "The current state of the Market",
+          "values": [
+            {
+              "name": "STATE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, invalid"
+            },
+            {
+              "name": "STATE_PROPOSED",
+              "number": "1",
+              "description": "The Governance proposal valid and accepted"
+            },
+            {
+              "name": "STATE_REJECTED",
+              "number": "2",
+              "description": "Outcome of governance votes is to reject the market"
+            },
+            {
+              "name": "STATE_PENDING",
+              "number": "3",
+              "description": "Governance vote passes/wins"
+            },
+            {
+              "name": "STATE_CANCELLED",
+              "number": "4",
+              "description": "Market triggers cancellation condition or governance\nvotes to close before market becomes Active"
+            },
+            {
+              "name": "STATE_ACTIVE",
+              "number": "5",
+              "description": "Enactment date reached and usual auction exit checks pass"
+            },
+            {
+              "name": "STATE_SUSPENDED",
+              "number": "6",
+              "description": "Price monitoring or liquidity monitoring trigger"
+            },
+            {
+              "name": "STATE_CLOSED",
+              "number": "7",
+              "description": "Governance vote (to close)"
+            },
+            {
+              "name": "STATE_TRADING_TERMINATED",
+              "number": "8",
+              "description": "Defined by the product (i.e. from a product parameter,\nspecified in market definition, giving close date/time)"
+            },
+            {
+              "name": "STATE_SETTLED",
+              "number": "9",
+              "description": "Settlement triggered and completed as defined by product"
+            }
+          ]
+        },
+        {
+          "name": "TradingMode",
+          "longName": "Market.TradingMode",
+          "fullName": "vega.Market.TradingMode",
+          "description": "The trading mode the market is currently running, also referred to as 'market state'",
+          "values": [
+            {
+              "name": "TRADING_MODE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, this is invalid"
+            },
+            {
+              "name": "TRADING_MODE_CONTINUOUS",
+              "number": "1",
+              "description": "Normal trading"
+            },
+            {
+              "name": "TRADING_MODE_BATCH_AUCTION",
+              "number": "2",
+              "description": "Auction trading (FBA)"
+            },
+            {
+              "name": "TRADING_MODE_OPENING_AUCTION",
+              "number": "3",
+              "description": "Opening auction"
+            },
+            {
+              "name": "TRADING_MODE_MONITORING_AUCTION",
+              "number": "4",
+              "description": "Auction triggered by monitoring"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "AuctionDuration",
+          "longName": "AuctionDuration",
+          "fullName": "vega.AuctionDuration",
+          "description": "An auction duration is used to configure 3 auction periods:\n1. `duration \u003e 0`, `volume == 0`:\n  The auction will last for at least N seconds\n2. `duration == 0`, `volume \u003e 0`:\n  The auction will end once we can close with given traded volume\n3. `duration \u003e 0`, `volume \u003e 0`:\n  The auction will take at least N seconds, but can end sooner if we can trade a certain volume",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "duration",
+              "description": "Duration of the auction in seconds",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "volume",
+              "description": "Target uncrossing trading volume",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ContinuousTrading",
+          "longName": "ContinuousTrading",
+          "fullName": "vega.ContinuousTrading",
+          "description": "Continuous trading",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tick_size",
+              "description": "Tick size",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DiscreteTrading",
+          "longName": "DiscreteTrading",
+          "fullName": "vega.DiscreteTrading",
+          "description": "Discrete trading",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "duration_ns",
+              "description": "Duration in nanoseconds, maximum 1 month (2592000000000000 ns)",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  },
+                  {
+                    "name": "int_lt",
+                    "value": 2592000000000000
+                  }
+                ]
+              }
+            },
+            {
+              "name": "tick_size",
+              "description": "Tick size",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FeeFactors",
+          "longName": "FeeFactors",
+          "fullName": "vega.FeeFactors",
+          "description": "Fee factors definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "maker_fee",
+              "description": "Maker fee",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "infrastructure_fee",
+              "description": "Infrastructure fee",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_fee",
+              "description": "Liquidity fee",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Fees",
+          "longName": "Fees",
+          "fullName": "vega.Fees",
+          "description": "Fees definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "factors",
+              "description": "Fee factors",
+              "label": "",
+              "type": "FeeFactors",
+              "longType": "FeeFactors",
+              "fullType": "vega.FeeFactors",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Future",
+          "longName": "Future",
+          "fullName": "vega.Future",
+          "description": "Future product definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "maturity",
+              "description": "The maturity for the future",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "settlement_asset",
+              "description": "The asset for the future",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "quote_name",
+              "description": "Quote name of the instrument",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "oracle_spec",
+              "description": "The oracle spec describing the oracle data of interest",
+              "label": "",
+              "type": "OracleSpec",
+              "longType": "oracles.v1.OracleSpec",
+              "fullType": "oracles.v1.OracleSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "oracle_spec_binding",
+              "description": "The binding between the oracle spec and the settlement price",
+              "label": "",
+              "type": "OracleSpecToFutureBinding",
+              "longType": "OracleSpecToFutureBinding",
+              "fullType": "vega.OracleSpecToFutureBinding",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Instrument",
+          "longName": "Instrument",
+          "fullName": "vega.Instrument",
+          "description": "Instrument definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Instrument identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "code",
+              "description": "Code for the instrument",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "Name of the instrument",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "metadata",
+              "description": "A collection of instrument meta-data",
+              "label": "",
+              "type": "InstrumentMetadata",
+              "longType": "InstrumentMetadata",
+              "fullType": "vega.InstrumentMetadata",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "future",
+              "description": "Future",
+              "label": "",
+              "type": "Future",
+              "longType": "Future",
+              "fullType": "vega.Future",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "product",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InstrumentMetadata",
+          "longName": "InstrumentMetadata",
+          "fullName": "vega.InstrumentMetadata",
+          "description": "Instrument metadata definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tags",
+              "description": "A list of 0 or more tags",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityMonitoringParameters",
+          "longName": "LiquidityMonitoringParameters",
+          "fullName": "vega.LiquidityMonitoringParameters",
+          "description": "LiquidityMonitoringParameters contains settings used for liquidity monitoring",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "target_stake_parameters",
+              "description": "Specifies parameters related to target stake calculation",
+              "label": "",
+              "type": "TargetStakeParameters",
+              "longType": "TargetStakeParameters",
+              "fullType": "vega.TargetStakeParameters",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "triggering_ratio",
+              "description": "Specifies the triggering ratio for entering liquidity auction",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_gte",
+                    "value": 0
+                  },
+                  {
+                    "name": "float_lte",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            {
+              "name": "auction_extension",
+              "description": "Specifies by how many seconds an auction should be extended if leaving the auction were to trigger a liquidity auction",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogNormalModelParams",
+          "longName": "LogNormalModelParams",
+          "fullName": "vega.LogNormalModelParams",
+          "description": "Risk model parameters for log normal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "mu",
+              "description": "Mu param",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "r",
+              "description": "R param",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sigma",
+              "description": "Sigma param",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LogNormalRiskModel",
+          "longName": "LogNormalRiskModel",
+          "fullName": "vega.LogNormalRiskModel",
+          "description": "Risk model for log normal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "risk_aversion_parameter",
+              "description": "Risk Aversion Parameter",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tau",
+              "description": "Tau",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "params",
+              "description": "Risk model parameters for log normal",
+              "label": "",
+              "type": "LogNormalModelParams",
+              "longType": "LogNormalModelParams",
+              "fullType": "vega.LogNormalModelParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginCalculator",
+          "longName": "MarginCalculator",
+          "fullName": "vega.MarginCalculator",
+          "description": "Margin Calculator definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "scaling_factors",
+              "description": "Scaling factors for margin calculation",
+              "label": "",
+              "type": "ScalingFactors",
+              "longType": "ScalingFactors",
+              "fullType": "vega.ScalingFactors",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Market",
+          "longName": "Market",
+          "fullName": "vega.Market",
+          "description": "Market definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tradable_instrument",
+              "description": "Tradable instrument configuration",
+              "label": "",
+              "type": "TradableInstrument",
+              "longType": "TradableInstrument",
+              "fullType": "vega.TradableInstrument",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "decimal_places",
+              "description": "Number of decimal places that a price must be shifted by in order to get a\ncorrect price denominated in the currency of the market, for example:\n`realPrice = price / 10^decimalPlaces`",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "fees",
+              "description": "Fees configuration",
+              "label": "",
+              "type": "Fees",
+              "longType": "Fees",
+              "fullType": "vega.Fees",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "opening_auction",
+              "description": "Auction duration specifies how long the opening auction will run (minimum\nduration and optionally a minimum traded volume)",
+              "label": "",
+              "type": "AuctionDuration",
+              "longType": "AuctionDuration",
+              "fullType": "vega.AuctionDuration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "continuous",
+              "description": "Continuous",
+              "label": "",
+              "type": "ContinuousTrading",
+              "longType": "ContinuousTrading",
+              "fullType": "vega.ContinuousTrading",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "trading_mode_config",
+              "defaultValue": ""
+            },
+            {
+              "name": "discrete",
+              "description": "Discrete",
+              "label": "",
+              "type": "DiscreteTrading",
+              "longType": "DiscreteTrading",
+              "fullType": "vega.DiscreteTrading",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "trading_mode_config",
+              "defaultValue": ""
+            },
+            {
+              "name": "price_monitoring_settings",
+              "description": "PriceMonitoringSettings for the market",
+              "label": "",
+              "type": "PriceMonitoringSettings",
+              "longType": "PriceMonitoringSettings",
+              "fullType": "vega.PriceMonitoringSettings",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_monitoring_parameters",
+              "description": "LiquidityMonitoringParameters for the market",
+              "label": "",
+              "type": "LiquidityMonitoringParameters",
+              "longType": "LiquidityMonitoringParameters",
+              "fullType": "vega.LiquidityMonitoringParameters",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trading_mode",
+              "description": "Current mode of execution of the market",
+              "label": "",
+              "type": "TradingMode",
+              "longType": "Market.TradingMode",
+              "fullType": "vega.Market.TradingMode",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "state",
+              "description": "Current state of the market",
+              "label": "",
+              "type": "State",
+              "longType": "Market.State",
+              "fullType": "vega.Market.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_timestamps",
+              "description": "Timestamps for when the market staye changes",
+              "label": "",
+              "type": "MarketTimestamps",
+              "longType": "MarketTimestamps",
+              "fullType": "vega.MarketTimestamps",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketTimestamps",
+          "longName": "MarketTimestamps",
+          "fullName": "vega.MarketTimestamps",
+          "description": "Time stamps for important times about creating, enacting etc the market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "proposed",
+              "description": "Time when the market is first proposed",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pending",
+              "description": "Time when the market has been voted in and is created into an opening auction",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "open",
+              "description": "Time when the market has left the opening auction and is ready to accept trades",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "close",
+              "description": "Time when the market is closed",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleSpecToFutureBinding",
+          "longName": "OracleSpecToFutureBinding",
+          "fullName": "vega.OracleSpecToFutureBinding",
+          "description": "OracleSpecToFutureBinding tells on which property oracle data should be\nused as settlement price.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "settlement_price_property",
+              "description": "settlement_price_property holds the name of the property in the oracle data\nthat should be used as settlement price.\nIf it is set to \"prices.BTC.value\", then the Future will use the value of\nthis property as settlement price.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PriceMonitoringParameters",
+          "longName": "PriceMonitoringParameters",
+          "fullName": "vega.PriceMonitoringParameters",
+          "description": "PriceMonitoringParameters contains a collection of triggers to be used for a given market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "triggers",
+              "description": "",
+              "label": "repeated",
+              "type": "PriceMonitoringTrigger",
+              "longType": "PriceMonitoringTrigger",
+              "fullType": "vega.PriceMonitoringTrigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PriceMonitoringSettings",
+          "longName": "PriceMonitoringSettings",
+          "fullName": "vega.PriceMonitoringSettings",
+          "description": "PriceMonitoringSettings contains the settings for price monitoring",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "parameters",
+              "description": "Specifies price monitoring parameters to be used for price monitoring purposes",
+              "label": "",
+              "type": "PriceMonitoringParameters",
+              "longType": "PriceMonitoringParameters",
+              "fullType": "vega.PriceMonitoringParameters",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update_frequency",
+              "description": "Specifies how often (expressed in seconds) the price monitoring bounds should be updated",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PriceMonitoringTrigger",
+          "longName": "PriceMonitoringTrigger",
+          "fullName": "vega.PriceMonitoringTrigger",
+          "description": "PriceMonitoringTrigger holds together price projection horizon τ, probability level p, and auction extension duration",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "horizon",
+              "description": "Price monitoring projection horizon τ in seconds",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "probability",
+              "description": "Price monitoirng probability level p",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_gt",
+                    "value": 0
+                  },
+                  {
+                    "name": "float_lt",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            {
+              "name": "auction_extension",
+              "description": "Price monitoring auction extension duration in seconds should the price\nbreach it's theoretical level over the specified horizon at the specified\nprobability level",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ScalingFactors",
+          "longName": "ScalingFactors",
+          "fullName": "vega.ScalingFactors",
+          "description": "Scaling Factors (for use in margin calculation)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "search_level",
+              "description": "Search level",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "initial_margin",
+              "description": "Initial margin level",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "collateral_release",
+              "description": "Collateral release level",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SimpleModelParams",
+          "longName": "SimpleModelParams",
+          "fullName": "vega.SimpleModelParams",
+          "description": "Risk model parameters for simple modelling",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "factor_long",
+              "description": "Pre-defined risk factor value for long",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "factor_short",
+              "description": "Pre-defined risk factor value for short",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_move_up",
+              "description": "Pre-defined maximum price move up that the model considers as valid",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_gte",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "min_move_down",
+              "description": "Pre-defined minimum price move down that the model considers as valid",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_lte",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "probability_of_trading",
+              "description": "Pre-defined constant probability of trading",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_gte",
+                    "value": 0
+                  },
+                  {
+                    "name": "float_lte",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "SimpleRiskModel",
+          "longName": "SimpleRiskModel",
+          "fullName": "vega.SimpleRiskModel",
+          "description": "Risk model for simple modelling",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "params",
+              "description": "Risk model params for simple modelling",
+              "label": "",
+              "type": "SimpleModelParams",
+              "longType": "SimpleModelParams",
+              "fullType": "vega.SimpleModelParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TargetStakeParameters",
+          "longName": "TargetStakeParameters",
+          "fullName": "vega.TargetStakeParameters",
+          "description": "TargetStakeParameters contains parameters used in target stake calculation",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "time_window",
+              "description": "Specifies length of time window expressed in seconds for target stake calculation",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "scaling_factor",
+              "description": "Specifies scaling factors used in target stake calculation",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "float_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "TradableInstrument",
+          "longName": "TradableInstrument",
+          "fullName": "vega.TradableInstrument",
+          "description": "Tradable Instrument definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "instrument",
+              "description": "Instrument details",
+              "label": "",
+              "type": "Instrument",
+              "longType": "Instrument",
+              "fullType": "vega.Instrument",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "margin_calculator",
+              "description": "Margin calculator for the instrument",
+              "label": "",
+              "type": "MarginCalculator",
+              "longType": "MarginCalculator",
+              "fullType": "vega.MarginCalculator",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "log_normal_risk_model",
+              "description": "Log normal",
+              "label": "",
+              "type": "LogNormalRiskModel",
+              "longType": "LogNormalRiskModel",
+              "fullType": "vega.LogNormalRiskModel",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "risk_model",
+              "defaultValue": ""
+            },
+            {
+              "name": "simple_risk_model",
+              "description": "Simple",
+              "label": "",
+              "type": "SimpleRiskModel",
+              "longType": "SimpleRiskModel",
+              "fullType": "vega.SimpleRiskModel",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "risk_model",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "vega.proto",
+      "description": "",
+      "package": "vega",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "AccountType",
+          "longName": "AccountType",
+          "fullName": "vega.AccountType",
+          "description": "Various collateral/account types as used by Vega",
+          "values": [
+            {
+              "name": "ACCOUNT_TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value"
+            },
+            {
+              "name": "ACCOUNT_TYPE_INSURANCE",
+              "number": "1",
+              "description": "Insurance pool accounts contain insurance pool funds for a market"
+            },
+            {
+              "name": "ACCOUNT_TYPE_SETTLEMENT",
+              "number": "2",
+              "description": "Settlement accounts exist only during settlement or mark-to-market"
+            },
+            {
+              "name": "ACCOUNT_TYPE_MARGIN",
+              "number": "3",
+              "description": "Margin accounts contain margin funds for a party and each party will\nhave multiple margin accounts, one for each market they have traded in\n\nMargin account funds will alter as margin requirements on positions change"
+            },
+            {
+              "name": "ACCOUNT_TYPE_GENERAL",
+              "number": "4",
+              "description": "General accounts contains general funds for a party. A party will\nhave multiple general accounts, one for each asset they want\nto trade with\n\nGeneral accounts are where funds are initially deposited or withdrawn from,\nit is also the account where funds are taken to fulfil fees and initial margin requirements"
+            },
+            {
+              "name": "ACCOUNT_TYPE_FEES_INFRASTRUCTURE",
+              "number": "5",
+              "description": "Infrastructure accounts contain fees earned by providing infrastructure on Vega"
+            },
+            {
+              "name": "ACCOUNT_TYPE_FEES_LIQUIDITY",
+              "number": "6",
+              "description": "Liquidity accounts contain fees earned by providing liquidity on Vega markets"
+            },
+            {
+              "name": "ACCOUNT_TYPE_FEES_MAKER",
+              "number": "7",
+              "description": "This account is created to hold fees earned by placing orders that sit on the book\nand are then matched with an incoming order to create a trade - These fees reward traders\nwho provide the best priced liquidity that actually allows trading to take place"
+            },
+            {
+              "name": "ACCOUNT_TYPE_LOCK_WITHDRAW",
+              "number": "8",
+              "description": "This account is created to lock funds to be withdrawn by parties"
+            },
+            {
+              "name": "ACCOUNT_TYPE_BOND",
+              "number": "9",
+              "description": "This account is created to maintain liquidity providers funds commitments"
+            },
+            {
+              "name": "ACCOUNT_TYPE_EXTERNAL",
+              "number": "10",
+              "description": "External account represents an external source (deposit/withdrawal)"
+            }
+          ]
+        },
+        {
+          "name": "AuctionTrigger",
+          "longName": "AuctionTrigger",
+          "fullName": "vega.AuctionTrigger",
+          "description": "Auction triggers indicate what condition triggered an auction (if market is in auction mode)",
+          "values": [
+            {
+              "name": "AUCTION_TRIGGER_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value for AuctionTrigger, no auction triggered"
+            },
+            {
+              "name": "AUCTION_TRIGGER_BATCH",
+              "number": "1",
+              "description": "Batch auction"
+            },
+            {
+              "name": "AUCTION_TRIGGER_OPENING",
+              "number": "2",
+              "description": "Opening auction"
+            },
+            {
+              "name": "AUCTION_TRIGGER_PRICE",
+              "number": "3",
+              "description": "Price monitoring trigger"
+            },
+            {
+              "name": "AUCTION_TRIGGER_LIQUIDITY",
+              "number": "4",
+              "description": "Liquidity monitoring trigger"
+            }
+          ]
+        },
+        {
+          "name": "ChainStatus",
+          "longName": "ChainStatus",
+          "fullName": "vega.ChainStatus",
+          "description": "The Vega blockchain status as reported by the node the caller is connected to",
+          "values": [
+            {
+              "name": "CHAIN_STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "CHAIN_STATUS_DISCONNECTED",
+              "number": "1",
+              "description": "Blockchain is disconnected"
+            },
+            {
+              "name": "CHAIN_STATUS_REPLAYING",
+              "number": "2",
+              "description": "Blockchain is replaying historic transactions"
+            },
+            {
+              "name": "CHAIN_STATUS_CONNECTED",
+              "number": "3",
+              "description": "Blockchain is connected and receiving transactions"
+            }
+          ]
+        },
+        {
+          "name": "Status",
+          "longName": "Deposit.Status",
+          "fullName": "vega.Deposit.Status",
+          "description": "The status of the deposit",
+          "values": [
+            {
+              "name": "STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "STATUS_OPEN",
+              "number": "1",
+              "description": "The deposit is being processed by the network"
+            },
+            {
+              "name": "STATUS_CANCELLED",
+              "number": "2",
+              "description": "The deposit has been cancelled by the network"
+            },
+            {
+              "name": "STATUS_FINALIZED",
+              "number": "3",
+              "description": "The deposit has been finalised and accounts have been updated"
+            }
+          ]
+        },
+        {
+          "name": "Interval",
+          "longName": "Interval",
+          "fullName": "vega.Interval",
+          "description": "Represents a set of time intervals that are used when querying for candle-stick data",
+          "values": [
+            {
+              "name": "INTERVAL_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "INTERVAL_I1M",
+              "number": "60",
+              "description": "1 minute."
+            },
+            {
+              "name": "INTERVAL_I5M",
+              "number": "300",
+              "description": "5 minutes."
+            },
+            {
+              "name": "INTERVAL_I15M",
+              "number": "900",
+              "description": "15 minutes."
+            },
+            {
+              "name": "INTERVAL_I1H",
+              "number": "3600",
+              "description": "1 hour."
+            },
+            {
+              "name": "INTERVAL_I6H",
+              "number": "21600",
+              "description": "6 hours."
+            },
+            {
+              "name": "INTERVAL_I1D",
+              "number": "86400",
+              "description": "1 day."
+            }
+          ]
+        },
+        {
+          "name": "Status",
+          "longName": "LiquidityProvision.Status",
+          "fullName": "vega.LiquidityProvision.Status",
+          "description": "Status of a liquidity provision order",
+          "values": [
+            {
+              "name": "STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "The default value"
+            },
+            {
+              "name": "STATUS_ACTIVE",
+              "number": "1",
+              "description": "The liquidity provision is active"
+            },
+            {
+              "name": "STATUS_STOPPED",
+              "number": "2",
+              "description": "The liquidity provision was stopped by the network"
+            },
+            {
+              "name": "STATUS_CANCELLED",
+              "number": "3",
+              "description": "The liquidity provision was cancelled by the liquidity provider"
+            },
+            {
+              "name": "STATUS_REJECTED",
+              "number": "4",
+              "description": "The liquidity provision was invalid and got rejected"
+            },
+            {
+              "name": "STATUS_UNDEPLOYED",
+              "number": "5",
+              "description": "The liquidity provision is valid and accepted by network, but orders aren't deployed"
+            },
+            {
+              "name": "STATUS_PENDING",
+              "number": "6",
+              "description": "The liquidity provision is valid and accepted by network\nbut have never been deployed. I when it's possible to deploy them for the first time\nmargin check fails, then they will be cancelled without any penalties."
+            }
+          ]
+        },
+        {
+          "name": "Status",
+          "longName": "Order.Status",
+          "fullName": "vega.Order.Status",
+          "description": "Status values for an order\nSee resulting status in [What order types are available to trade on Vega?](https://docs.testnet.vega.xyz/docs/trading-questions/#what-order-types-are-available-to-trade-on-vega) for more detail.",
+          "values": [
+            {
+              "name": "STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "STATUS_ACTIVE",
+              "number": "1",
+              "description": "Used for active unfilled or partially filled orders"
+            },
+            {
+              "name": "STATUS_EXPIRED",
+              "number": "2",
+              "description": "Used for expired GTT orders"
+            },
+            {
+              "name": "STATUS_CANCELLED",
+              "number": "3",
+              "description": "Used for orders cancelled by the party that created the order"
+            },
+            {
+              "name": "STATUS_STOPPED",
+              "number": "4",
+              "description": "Used for unfilled FOK or IOC orders, and for orders that were stopped by the network"
+            },
+            {
+              "name": "STATUS_FILLED",
+              "number": "5",
+              "description": "Used for closed fully filled orders"
+            },
+            {
+              "name": "STATUS_REJECTED",
+              "number": "6",
+              "description": "Used for orders when not enough collateral was available to fill the margin requirements"
+            },
+            {
+              "name": "STATUS_PARTIALLY_FILLED",
+              "number": "7",
+              "description": "Used for closed partially filled IOC orders"
+            },
+            {
+              "name": "STATUS_PARKED",
+              "number": "8",
+              "description": "Order has been removed from the order book and has been parked, this applies to pegged orders only"
+            }
+          ]
+        },
+        {
+          "name": "TimeInForce",
+          "longName": "Order.TimeInForce",
+          "fullName": "vega.Order.TimeInForce",
+          "description": "Time In Force for an order\nSee [What order types are available to trade on Vega?](https://docs.testnet.vega.xyz/docs/trading-questions/#what-order-types-are-available-to-trade-on-vega) for more detail",
+          "values": [
+            {
+              "name": "TIME_IN_FORCE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value for TimeInForce, can be valid for an amend"
+            },
+            {
+              "name": "TIME_IN_FORCE_GTC",
+              "number": "1",
+              "description": "Good until cancelled"
+            },
+            {
+              "name": "TIME_IN_FORCE_GTT",
+              "number": "2",
+              "description": "Good until specified time"
+            },
+            {
+              "name": "TIME_IN_FORCE_IOC",
+              "number": "3",
+              "description": "Immediate or cancel"
+            },
+            {
+              "name": "TIME_IN_FORCE_FOK",
+              "number": "4",
+              "description": "Fill or kill"
+            },
+            {
+              "name": "TIME_IN_FORCE_GFA",
+              "number": "5",
+              "description": "Good for auction"
+            },
+            {
+              "name": "TIME_IN_FORCE_GFN",
+              "number": "6",
+              "description": "Good for normal"
+            }
+          ]
+        },
+        {
+          "name": "Type",
+          "longName": "Order.Type",
+          "fullName": "vega.Order.Type",
+          "description": "Type values for an order",
+          "values": [
+            {
+              "name": "TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "TYPE_LIMIT",
+              "number": "1",
+              "description": "Used for Limit orders"
+            },
+            {
+              "name": "TYPE_MARKET",
+              "number": "2",
+              "description": "Used for Market orders"
+            },
+            {
+              "name": "TYPE_NETWORK",
+              "number": "3",
+              "description": "Used for orders where the initiating party is the network (with distressed traders)"
+            }
+          ]
+        },
+        {
+          "name": "OrderError",
+          "longName": "OrderError",
+          "fullName": "vega.OrderError",
+          "description": "OrderError codes are returned in the `[Order](#vega.Order).reason` field - If there is an issue\nwith an order during its life-cycle, it will be marked with `status.ORDER_STATUS_REJECTED`",
+          "values": [
+            {
+              "name": "ORDER_ERROR_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, no error reported"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_MARKET_ID",
+              "number": "1",
+              "description": "Order was submitted for a market that does not exist"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_ORDER_ID",
+              "number": "2",
+              "description": "Order was submitted with an invalid identifier"
+            },
+            {
+              "name": "ORDER_ERROR_OUT_OF_SEQUENCE",
+              "number": "3",
+              "description": "Order was amended with a sequence number that was not previous version + 1"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_REMAINING_SIZE",
+              "number": "4",
+              "description": "Order was amended with an invalid remaining size (e.g. remaining greater than total size)"
+            },
+            {
+              "name": "ORDER_ERROR_TIME_FAILURE",
+              "number": "5",
+              "description": "Node was unable to get Vega (blockchain) time"
+            },
+            {
+              "name": "ORDER_ERROR_REMOVAL_FAILURE",
+              "number": "6",
+              "description": "Failed to remove an order from the book"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_EXPIRATION_DATETIME",
+              "number": "7",
+              "description": "An order with `TimeInForce.TIME_IN_FORCE_GTT` was submitted or amended\nwith an expiration that was badly formatted or otherwise invalid"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_ORDER_REFERENCE",
+              "number": "8",
+              "description": "Order was submitted or amended with an invalid reference field"
+            },
+            {
+              "name": "ORDER_ERROR_EDIT_NOT_ALLOWED",
+              "number": "9",
+              "description": "Order amend was submitted for an order field that cannot not be amended (e.g. order identifier)"
+            },
+            {
+              "name": "ORDER_ERROR_AMEND_FAILURE",
+              "number": "10",
+              "description": "Amend failure because amend details do not match original order"
+            },
+            {
+              "name": "ORDER_ERROR_NOT_FOUND",
+              "number": "11",
+              "description": "Order not found in an order book or store"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_PARTY_ID",
+              "number": "12",
+              "description": "Order was submitted with an invalid or missing party identifier"
+            },
+            {
+              "name": "ORDER_ERROR_MARKET_CLOSED",
+              "number": "13",
+              "description": "Order was submitted for a market that has closed"
+            },
+            {
+              "name": "ORDER_ERROR_MARGIN_CHECK_FAILED",
+              "number": "14",
+              "description": "Order was submitted, but the party did not have enough collateral to cover the order"
+            },
+            {
+              "name": "ORDER_ERROR_MISSING_GENERAL_ACCOUNT",
+              "number": "15",
+              "description": "Order was submitted, but the party did not have an account for this asset"
+            },
+            {
+              "name": "ORDER_ERROR_INTERNAL_ERROR",
+              "number": "16",
+              "description": "Unspecified internal error"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_SIZE",
+              "number": "17",
+              "description": "Order was submitted with an invalid or missing size (e.g. 0)"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_PERSISTENCE",
+              "number": "18",
+              "description": "Order was submitted with an invalid persistence for its type"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_TYPE",
+              "number": "19",
+              "description": "Order was submitted with an invalid type field"
+            },
+            {
+              "name": "ORDER_ERROR_SELF_TRADING",
+              "number": "20",
+              "description": "Order was stopped as it would have traded with another order submitted from the same party"
+            },
+            {
+              "name": "ORDER_ERROR_INSUFFICIENT_FUNDS_TO_PAY_FEES",
+              "number": "21",
+              "description": "Order was submitted, but the party did not have enough collateral to cover the fees for the order"
+            },
+            {
+              "name": "ORDER_ERROR_INCORRECT_MARKET_TYPE",
+              "number": "22",
+              "description": "Order was submitted with an incorrect or invalid market type"
+            },
+            {
+              "name": "ORDER_ERROR_INVALID_TIME_IN_FORCE",
+              "number": "23",
+              "description": "Order was submitted with invalid time in force"
+            },
+            {
+              "name": "ORDER_ERROR_GFN_ORDER_DURING_AN_AUCTION",
+              "number": "24",
+              "description": "A GFN order has got to the market when it is in auction mode"
+            },
+            {
+              "name": "ORDER_ERROR_GFA_ORDER_DURING_CONTINUOUS_TRADING",
+              "number": "25",
+              "description": "A GFA order has got to the market when it is in continuous trading mode"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_AMEND_TO_GTT_WITHOUT_EXPIRYAT",
+              "number": "26",
+              "description": "Attempt to amend order to GTT without ExpiryAt"
+            },
+            {
+              "name": "ORDER_ERROR_EXPIRYAT_BEFORE_CREATEDAT",
+              "number": "27",
+              "description": "Attempt to amend ExpiryAt to a value before CreatedAt"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_HAVE_GTC_AND_EXPIRYAT",
+              "number": "28",
+              "description": "Attempt to amend to GTC without an ExpiryAt value"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_AMEND_TO_FOK_OR_IOC",
+              "number": "29",
+              "description": "Amending to FOK or IOC is invalid"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_AMEND_TO_GFA_OR_GFN",
+              "number": "30",
+              "description": "Amending to GFA or GFN is invalid"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_AMEND_FROM_GFA_OR_GFN",
+              "number": "31",
+              "description": "Amending from GFA or GFN is invalid"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_SEND_IOC_ORDER_DURING_AUCTION",
+              "number": "32",
+              "description": "IOC orders are not allowed during auction"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_SEND_FOK_ORDER_DURING_AUCTION",
+              "number": "33",
+              "description": "FOK orders are not allowed during auction"
+            },
+            {
+              "name": "ORDER_ERROR_MUST_BE_LIMIT_ORDER",
+              "number": "34",
+              "description": "Pegged orders must be LIMIT orders"
+            },
+            {
+              "name": "ORDER_ERROR_MUST_BE_GTT_OR_GTC",
+              "number": "35",
+              "description": "Pegged orders can only have TIF GTC or GTT"
+            },
+            {
+              "name": "ORDER_ERROR_WITHOUT_REFERENCE_PRICE",
+              "number": "36",
+              "description": "Pegged order must have a reference price"
+            },
+            {
+              "name": "ORDER_ERROR_BUY_CANNOT_REFERENCE_BEST_ASK_PRICE",
+              "number": "37",
+              "description": "Buy pegged order cannot reference best ask price"
+            },
+            {
+              "name": "ORDER_ERROR_OFFSET_MUST_BE_LESS_OR_EQUAL_TO_ZERO",
+              "number": "38",
+              "description": "Pegged order offset must be \u003c= 0"
+            },
+            {
+              "name": "ORDER_ERROR_OFFSET_MUST_BE_LESS_THAN_ZERO",
+              "number": "39",
+              "description": "Pegged order offset must be \u003c 0"
+            },
+            {
+              "name": "ORDER_ERROR_OFFSET_MUST_BE_GREATER_OR_EQUAL_TO_ZERO",
+              "number": "40",
+              "description": "Pegged order offset must be \u003e= 0"
+            },
+            {
+              "name": "ORDER_ERROR_SELL_CANNOT_REFERENCE_BEST_BID_PRICE",
+              "number": "41",
+              "description": "Sell pegged order cannot reference best bid price"
+            },
+            {
+              "name": "ORDER_ERROR_OFFSET_MUST_BE_GREATER_THAN_ZERO",
+              "number": "42",
+              "description": "Pegged order offset must be \u003e zero"
+            },
+            {
+              "name": "ORDER_ERROR_INSUFFICIENT_ASSET_BALANCE",
+              "number": "43",
+              "description": "The party has an insufficient balance, or does not have\na general account to submit the order (no deposits made\nfor the required asset)"
+            },
+            {
+              "name": "ORDER_ERROR_CANNOT_AMEND_PEGGED_ORDER_DETAILS_ON_NON_PEGGED_ORDER",
+              "number": "44",
+              "description": "Cannot amend a non pegged orders details"
+            },
+            {
+              "name": "ORDER_ERROR_UNABLE_TO_REPRICE_PEGGED_ORDER",
+              "number": "45",
+              "description": "We are unable to re-price a pegged order because a market price is unavailable"
+            },
+            {
+              "name": "ORDER_ERROR_UNABLE_TO_AMEND_PRICE_ON_PEGGED_ORDER",
+              "number": "46",
+              "description": "It is not possible to amend the price of an existing pegged order"
+            },
+            {
+              "name": "ORDER_ERROR_NON_PERSISTENT_ORDER_OUT_OF_PRICE_BOUNDS",
+              "number": "47",
+              "description": "An FOK, IOC, or GFN order was rejected because it resulted in trades outside the price bounds"
+            }
+          ]
+        },
+        {
+          "name": "PeggedReference",
+          "longName": "PeggedReference",
+          "fullName": "vega.PeggedReference",
+          "description": "A pegged reference defines which price point a pegged order is linked to - meaning\nthe price for a pegged order is calculated from the value of the reference price point",
+          "values": [
+            {
+              "name": "PEGGED_REFERENCE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value for PeggedReference, no reference given"
+            },
+            {
+              "name": "PEGGED_REFERENCE_MID",
+              "number": "1",
+              "description": "Mid price reference"
+            },
+            {
+              "name": "PEGGED_REFERENCE_BEST_BID",
+              "number": "2",
+              "description": "Best bid price reference"
+            },
+            {
+              "name": "PEGGED_REFERENCE_BEST_ASK",
+              "number": "3",
+              "description": "Best ask price reference"
+            }
+          ]
+        },
+        {
+          "name": "Side",
+          "longName": "Side",
+          "fullName": "vega.Side",
+          "description": "A side relates to the direction of an order, to Buy, or Sell",
+          "values": [
+            {
+              "name": "SIDE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "SIDE_BUY",
+              "number": "1",
+              "description": "Buy order"
+            },
+            {
+              "name": "SIDE_SELL",
+              "number": "2",
+              "description": "Sell order"
+            }
+          ]
+        },
+        {
+          "name": "Type",
+          "longName": "Trade.Type",
+          "fullName": "vega.Trade.Type",
+          "description": "Type values for a trade",
+          "values": [
+            {
+              "name": "TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "TYPE_DEFAULT",
+              "number": "1",
+              "description": "Normal trading between two parties"
+            },
+            {
+              "name": "TYPE_NETWORK_CLOSE_OUT_GOOD",
+              "number": "2",
+              "description": "Trading initiated by the network with another party on the book,\nwhich helps to zero-out the positions of one or more distressed parties"
+            },
+            {
+              "name": "TYPE_NETWORK_CLOSE_OUT_BAD",
+              "number": "3",
+              "description": "Trading initiated by the network with another party off the book,\nwith a distressed party in order to zero-out the position of the party"
+            }
+          ]
+        },
+        {
+          "name": "TransferType",
+          "longName": "TransferType",
+          "fullName": "vega.TransferType",
+          "description": "Transfers can occur between parties on Vega, these are the types that indicate why a transfer took place",
+          "values": [
+            {
+              "name": "TRANSFER_TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "TRANSFER_TYPE_LOSS",
+              "number": "1",
+              "description": "Loss"
+            },
+            {
+              "name": "TRANSFER_TYPE_WIN",
+              "number": "2",
+              "description": "Win"
+            },
+            {
+              "name": "TRANSFER_TYPE_CLOSE",
+              "number": "3",
+              "description": "Close"
+            },
+            {
+              "name": "TRANSFER_TYPE_MTM_LOSS",
+              "number": "4",
+              "description": "Mark to market loss"
+            },
+            {
+              "name": "TRANSFER_TYPE_MTM_WIN",
+              "number": "5",
+              "description": "Mark to market win"
+            },
+            {
+              "name": "TRANSFER_TYPE_MARGIN_LOW",
+              "number": "6",
+              "description": "Margin too low"
+            },
+            {
+              "name": "TRANSFER_TYPE_MARGIN_HIGH",
+              "number": "7",
+              "description": "Margin too high"
+            },
+            {
+              "name": "TRANSFER_TYPE_MARGIN_CONFISCATED",
+              "number": "8",
+              "description": "Margin was confiscated"
+            },
+            {
+              "name": "TRANSFER_TYPE_MAKER_FEE_PAY",
+              "number": "9",
+              "description": "Pay maker fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_MAKER_FEE_RECEIVE",
+              "number": "10",
+              "description": "Receive maker fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_INFRASTRUCTURE_FEE_PAY",
+              "number": "11",
+              "description": "Pay infrastructure fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_INFRASTRUCTURE_FEE_DISTRIBUTE",
+              "number": "12",
+              "description": "Receive infrastructure fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_LIQUIDITY_FEE_PAY",
+              "number": "13",
+              "description": "Pay liquidity fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_LIQUIDITY_FEE_DISTRIBUTE",
+              "number": "14",
+              "description": "Receive liquidity fee"
+            },
+            {
+              "name": "TRANSFER_TYPE_BOND_LOW",
+              "number": "15",
+              "description": "Bond too low"
+            },
+            {
+              "name": "TRANSFER_TYPE_BOND_HIGH",
+              "number": "16",
+              "description": "Bond too high"
+            },
+            {
+              "name": "TRANSFER_TYPE_WITHDRAW_LOCK",
+              "number": "17",
+              "description": "Lock amount for withdraw"
+            },
+            {
+              "name": "TRANSFER_TYPE_WITHDRAW",
+              "number": "18",
+              "description": "Actual withdraw from system"
+            },
+            {
+              "name": "TRANSFER_TYPE_DEPOSIT",
+              "number": "19",
+              "description": "Deposit funds"
+            },
+            {
+              "name": "TRANSFER_TYPE_BOND_SLASHING",
+              "number": "20",
+              "description": "Bond slashing"
+            }
+          ]
+        },
+        {
+          "name": "Status",
+          "longName": "Withdrawal.Status",
+          "fullName": "vega.Withdrawal.Status",
+          "description": "The status of the withdrawal",
+          "values": [
+            {
+              "name": "STATUS_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "STATUS_OPEN",
+              "number": "1",
+              "description": "The withdrawal is open and being processed by the network"
+            },
+            {
+              "name": "STATUS_CANCELLED",
+              "number": "2",
+              "description": "The withdrawal have been cancelled"
+            },
+            {
+              "name": "STATUS_FINALIZED",
+              "number": "3",
+              "description": "The withdrawal went through and is fully finalised, the funds are removed from the\nVega network and are unlocked on the foreign chain bridge, for example, on the Ethereum network"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Account",
+          "longName": "Account",
+          "fullName": "vega.Account",
+          "description": "Represents an account for an asset on Vega for a particular owner or party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique account identifier (used internally by Vega)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "owner",
+              "description": "The party that the account belongs to, special values include `network`, which represents the Vega network and is\nmost commonly seen during liquidation of distressed trading positions",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "balance",
+              "description": "Balance of the asset, the balance is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places\nand importantly balances cannot be negative",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier for the account",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier for the account, if [`AccountType`](#vega.AccountType).`ACCOUNT_TYPE_GENERAL` this will be empty",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "The account type related to this account",
+              "label": "",
+              "type": "AccountType",
+              "longType": "AccountType",
+              "fullType": "vega.AccountType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AuctionIndicativeState",
+          "longName": "AuctionIndicativeState",
+          "fullName": "vega.AuctionIndicativeState",
+          "description": "AuctionIndicativeState is used to emit an event with the indicative price/volume per market during an auction",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "The market identifier for which this state relates to",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "indicative_price",
+              "description": "The Indicative Uncrossing Price is the price at which all trades would occur if we uncrossed the auction now",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "indicative_volume",
+              "description": "The Indicative Uncrossing Volume is the volume available at the Indicative crossing price if we uncrossed the auction now",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auction_start",
+              "description": "The timestamp at which the auction started",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auction_end",
+              "description": "The timestamp at which the auction is meant to stop",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Candle",
+          "longName": "Candle",
+          "fullName": "vega.Candle",
+          "description": "Represents the high, low, open, and closing prices for an interval of trading,\nreferred to commonly as a candlestick or candle",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "timestamp",
+              "description": "Timestamp for the point in time when the candle was initially created/opened, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "datetime",
+              "description": "An ISO-8601 datetime with nanosecond precision for when the candle was last updated",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "high",
+              "description": "Highest price for trading during the candle interval",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "low",
+              "description": "Lowest price for trading during the candle interval",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "open",
+              "description": "Open trade price",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "close",
+              "description": "Closing trade price",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "volume",
+              "description": "Total trading volume during the candle interval",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "interval",
+              "description": "Time interval for the candle - See [`Interval`](#vega.Interval)",
+              "label": "",
+              "type": "Interval",
+              "longType": "Interval",
+              "fullType": "vega.Interval",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Deposit",
+          "longName": "Deposit",
+          "fullName": "vega.Deposit",
+          "description": "A deposit on to the Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier for the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "Status of the deposit",
+              "label": "",
+              "type": "Status",
+              "longType": "Deposit.Status",
+              "fullType": "vega.Deposit.Status",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier of the user initiating the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "The Vega asset targeted by this deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be deposited",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tx_hash",
+              "description": "The hash of the transaction from the foreign chain",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "credited_timestamp",
+              "description": "Timestamp for when the Vega account was updated with the deposit",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_timestamp",
+              "description": "Timestamp for when the deposit was created on the Vega network",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Erc20WithdrawExt",
+          "longName": "Erc20WithdrawExt",
+          "fullName": "vega.Erc20WithdrawExt",
+          "description": "An extension of data required for the withdraw submissions",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "receiver_address",
+              "description": "The address into which the bridge will release the funds",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ErrorDetail",
+          "longName": "ErrorDetail",
+          "fullName": "vega.ErrorDetail",
+          "description": "Represents Vega domain specific error information over gRPC/Protobuf",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "code",
+              "description": "A Vega API domain specific unique error code, useful for client side mappings, e.g. 10004",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "message",
+              "description": "A message that describes the error in more detail, should describe the problem encountered",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "inner",
+              "description": "Any inner error information that could add more context, or be helpful for error reporting",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EthereumConfig",
+          "longName": "EthereumConfig",
+          "fullName": "vega.EthereumConfig",
+          "description": "Ethereum configuration details",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "network_id",
+              "description": "Network identifier of this Ethereum network",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chain_id",
+              "description": "Chain identifier of this Ethereum network",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "bridge_address",
+              "description": "Bridge address for this Ethereum network",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "confirmations",
+              "description": "Number of confirmations",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Fee",
+          "longName": "Fee",
+          "fullName": "vega.Fee",
+          "description": "Represents any fees paid by a party, resulting from a trade",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "maker_fee",
+              "description": "Fee amount paid to the non-aggressive party of the trade",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "infrastructure_fee",
+              "description": "Fee amount paid for maintaining the Vega infrastructure",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_fee",
+              "description": "Fee amount paid to market makers",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FinancialAmount",
+          "longName": "FinancialAmount",
+          "fullName": "vega.FinancialAmount",
+          "description": "Asset value information used within a transfer",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "amount",
+              "description": "A signed integer amount of asset",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LedgerEntry",
+          "longName": "LedgerEntry",
+          "fullName": "vega.LedgerEntry",
+          "description": "Represents a ledger entry on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "from_account",
+              "description": "One or more accounts to transfer from",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "to_account",
+              "description": "One or more accounts to transfer to",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "An amount to transfer",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "A reference for auditing purposes",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type of ledger entry",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "Timestamp for the time the ledger entry was created, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityOrder",
+          "longName": "LiquidityOrder",
+          "fullName": "vega.LiquidityOrder",
+          "description": "Represents a liquidity order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "reference",
+              "description": "The pegged reference point for the order",
+              "label": "",
+              "type": "PeggedReference",
+              "longType": "PeggedReference",
+              "fullType": "vega.PeggedReference",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "proportion",
+              "description": "The relative proportion of the commitment to be allocated at a price level",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "offset",
+              "description": "The offset/amount of units away for the order",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityOrderReference",
+          "longName": "LiquidityOrderReference",
+          "fullName": "vega.LiquidityOrderReference",
+          "description": "A pair of a liquidity order and the id of the generated order by the core",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Unique identifier of the pegged order generated by the core to fulfil this liquidity order",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_order",
+              "description": "The liquidity order from the original submission",
+              "label": "",
+              "type": "LiquidityOrder",
+              "longType": "LiquidityOrder",
+              "fullType": "vega.LiquidityOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityProviderFeeShare",
+          "longName": "LiquidityProviderFeeShare",
+          "fullName": "vega.LiquidityProviderFeeShare",
+          "description": "The equity like share of liquidity fee for each liquidity provider",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party",
+              "description": "The liquidity provider party id",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "equity_like_share",
+              "description": "The share own by this liquidity provider (float)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "average_entry_valuation",
+              "description": "The average entry valuation of the liquidity provider for the market",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityProvision",
+          "longName": "LiquidityProvision",
+          "fullName": "vega.LiquidityProvision",
+          "description": "An Liquidity provider commitment",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Unique party identifier for the creator of the provision",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "Timestamp for when the order was created at, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "updated_at",
+              "description": "Timestamp for when the order was updated at, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier for the order, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "commitment_amount",
+              "description": "Specified as a unitless number that represents the amount of settlement asset of the market",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "fee",
+              "description": "Nominated liquidity fee factor, which is an input to the calculation of taker fees on the market, as per seeting fees and rewarding liquidity providers",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sells",
+              "description": "A set of liquidity sell orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrderReference",
+              "longType": "LiquidityOrderReference",
+              "fullType": "vega.LiquidityOrderReference",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buys",
+              "description": "A set of liquidity buy orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrderReference",
+              "longType": "LiquidityOrderReference",
+              "fullType": "vega.LiquidityOrderReference",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "Version of this liquidity provision order",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "Status of this liquidity provision order",
+              "label": "",
+              "type": "Status",
+              "longType": "LiquidityProvision.Status",
+              "fullType": "vega.LiquidityProvision.Status",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "A reference shared between this liquidity provision and all it's orders",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginLevels",
+          "longName": "MarginLevels",
+          "fullName": "vega.MarginLevels",
+          "description": "Represents the margin levels for a party on a market at a given time",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "maintenance_margin",
+              "description": "Maintenance margin value",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "search_level",
+              "description": "Search level value",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "initial_margin",
+              "description": "Initial margin value",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "collateral_release_level",
+              "description": "Collateral release level value",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "Timestamp for the time the ledger entry was created, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketData",
+          "longName": "MarketData",
+          "fullName": "vega.MarketData",
+          "description": "Represents data generated by a market when open",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "mark_price",
+              "description": "Mark price, as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_bid_price",
+              "description": "Highest price level on an order book for buy orders, as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_bid_volume",
+              "description": "Aggregated volume being bid at the best bid price",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_offer_price",
+              "description": "Lowest price level on an order book for offer orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_offer_volume",
+              "description": "Aggregated volume being offered at the best offer price, as an integer, for example `123456` is a correctly\n // formatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_static_bid_price",
+              "description": "Highest price on the order book for buy orders not including pegged orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_static_bid_volume",
+              "description": "Total volume at the best static bid price excluding pegged orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_static_offer_price",
+              "description": "Lowest price on the order book for sell orders not including pegged orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "best_static_offer_volume",
+              "description": "Total volume at the best static offer price excluding pegged orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "mid_price",
+              "description": "Arithmetic average of the best bid price and best offer price, as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "static_mid_price",
+              "description": "Arithmetic average of the best static bid price and best static offer price",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market",
+              "description": "Market identifier for the data",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "Timestamp at which this mark price was relevant, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "open_interest",
+              "description": "The sum of the size of all positions greater than 0 on the market",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auction_end",
+              "description": "Time in seconds until the end of the auction (0 if currently not in auction period)",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "auction_start",
+              "description": "Time until next auction (used in FBA's) - currently always 0",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "indicative_price",
+              "description": "Indicative price (zero if not in auction)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "indicative_volume",
+              "description": "Indicative volume (zero if not in auction)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_trading_mode",
+              "description": "The current trading mode for the market",
+              "label": "",
+              "type": "TradingMode",
+              "longType": "Market.TradingMode",
+              "fullType": "vega.Market.TradingMode",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "When a market is in an auction trading mode, this field indicates what triggered the auction",
+              "label": "",
+              "type": "AuctionTrigger",
+              "longType": "AuctionTrigger",
+              "fullType": "vega.AuctionTrigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "target_stake",
+              "description": "Targeted stake for the given market",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "supplied_stake",
+              "description": "Available stake for the given market",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price_monitoring_bounds",
+              "description": "One or more price monitoring bounds for the current timestamp",
+              "label": "repeated",
+              "type": "PriceMonitoringBounds",
+              "longType": "PriceMonitoringBounds",
+              "fullType": "vega.PriceMonitoringBounds",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_value_proxy",
+              "description": "the market value proxy",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_provider_fee_share",
+              "description": "the equity like share of liquidity fee for each liquidity provider",
+              "label": "repeated",
+              "type": "LiquidityProviderFeeShare",
+              "longType": "LiquidityProviderFeeShare",
+              "fullType": "vega.LiquidityProviderFeeShare",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepth",
+          "longName": "MarketDepth",
+          "fullName": "vega.MarketDepth",
+          "description": "Represents market depth or order book data for the specified market on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buy",
+              "description": "Collection of price levels for the buy side of the book",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sell",
+              "description": "Collection of price levels for the sell side of the book",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sequence_number",
+              "description": "Sequence number for the market depth data returned",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthUpdate",
+          "longName": "MarketDepthUpdate",
+          "fullName": "vega.MarketDepthUpdate",
+          "description": "Represents the changed market depth since the last update",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buy",
+              "description": "Collection of updated price levels for the buy side of the book",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sell",
+              "description": "Collection of updated price levels for the sell side of the book",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sequence_number",
+              "description": "Sequence number for the market depth update data returned",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NetworkParameter",
+          "longName": "NetworkParameter",
+          "fullName": "vega.NetworkParameter",
+          "description": "Represents a network parameter on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "The unique key",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "The value for the network parameter",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Order",
+          "longName": "Order",
+          "fullName": "vega.Order",
+          "description": "An order can be submitted, amended and cancelled on Vega in an attempt to make trades with other parties",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier for the order (set by the system after consensus)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier for the order",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier for the order",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "side",
+              "description": "Side for the order, e.g. SIDE_BUY or SIDE_SELL - See [`Side`](#vega.Side)",
+              "label": "",
+              "type": "Side",
+              "longType": "Side",
+              "fullType": "vega.Side",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price for the order, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size",
+              "description": "Size for the order, for example, in a futures market the size equals the number of contracts",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "remaining",
+              "description": "Size remaining, when this reaches 0 then the order is fully filled and status becomes STATUS_FILLED",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time_in_force",
+              "description": "Time in force indicates how long an order will remain active before it is executed or expires.\n- See [`Order.TimeInForce`](#vega.Order.TimeInForce)",
+              "label": "",
+              "type": "TimeInForce",
+              "longType": "Order.TimeInForce",
+              "fullType": "vega.Order.TimeInForce",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type for the order - See [`Order.Type`](#vega.Order.Type)",
+              "label": "",
+              "type": "Type",
+              "longType": "Order.Type",
+              "fullType": "vega.Order.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_at",
+              "description": "Timestamp for when the order was created at, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "The current status for the order. See [`Order.Status`](#vega.Order.Status)\n- For detail on `STATUS_REJECTED` please check the [`OrderError`](#vega.OrderError) value given in the `reason` field",
+              "label": "",
+              "type": "Status",
+              "longType": "Order.Status",
+              "fullType": "vega.Order.Status",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expires_at",
+              "description": "Timestamp for when the order will expire, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`, valid only for [`Order.TimeInForce`](#vega.Order.TimeInForce)`.TIME_IN_FORCE_GTT`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "Reference given for the order, this is typically used to retrieve an order submitted through consensus\n- Currently set internally by the node to return a unique reference identifier for the order submission",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reason",
+              "description": "If the Order `status` is `STATUS_REJECTED` then an [`OrderError`](#vega.OrderError) reason will be specified\n- The default for this field is `ORDER_ERROR_NONE` which signifies that there were no errors",
+              "label": "",
+              "type": "OrderError",
+              "longType": "OrderError",
+              "fullType": "vega.OrderError",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "updated_at",
+              "description": "Timestamp for when the Order was last updated, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "The version for the order, initial value is version 1 and is incremented after each successful amend",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "batch_id",
+              "description": "Batch identifier for the order, used internally for orders submitted during auctions\nto keep track of the auction batch this order falls under (required for fees calculation)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pegged_order",
+              "description": "Pegged order details, used only if the order represents a pegged order.",
+              "label": "",
+              "type": "PeggedOrder",
+              "longType": "PeggedOrder",
+              "fullType": "vega.PeggedOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_provision_id",
+              "description": "Is this order created as part of a liquidity provision, will be empty if not.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderCancellationConfirmation",
+          "longName": "OrderCancellationConfirmation",
+          "fullName": "vega.OrderCancellationConfirmation",
+          "description": "Used when cancelling an Order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "The order that was cancelled",
+              "label": "",
+              "type": "Order",
+              "longType": "Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderConfirmation",
+          "longName": "OrderConfirmation",
+          "fullName": "vega.OrderConfirmation",
+          "description": "Used when confirming an Order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "The order that was confirmed",
+              "label": "",
+              "type": "Order",
+              "longType": "Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trades",
+              "description": "0 or more trades that were emitted",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "passive_orders_affected",
+              "description": "0 or more passive orders that were affected",
+              "label": "repeated",
+              "type": "Order",
+              "longType": "Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Party",
+          "longName": "Party",
+          "fullName": "vega.Party",
+          "description": "A party represents an entity who wishes to trade on or query a Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "A unique identifier for the party, typically represented by a public key",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PeggedOrder",
+          "longName": "PeggedOrder",
+          "fullName": "vega.PeggedOrder",
+          "description": "Pegged orders are limit orders where the price is specified in the form REFERENCE +/- OFFSET\nThey can be used for any limit order that is valid during continuous trading",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "reference",
+              "description": "Which price point are we linked to",
+              "label": "",
+              "type": "PeggedReference",
+              "longType": "PeggedReference",
+              "fullType": "vega.PeggedReference",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "offset",
+              "description": "Offset from the price reference",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Position",
+          "longName": "Position",
+          "fullName": "vega.Position",
+          "description": "Represents position data for a party on the specified market on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "open_volume",
+              "description": "Open volume for the position, value is signed +ve for long and -ve for short",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "realised_pnl",
+              "description": "Realised profit and loss for the position, value is signed +ve for long and -ve for short",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "unrealised_pnl",
+              "description": "Unrealised profit and loss for the position, value is signed +ve for long and -ve for short",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "average_entry_price",
+              "description": "Average entry price for the position, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "updated_at",
+              "description": "Timestamp for the latest time the position was updated",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionTrade",
+          "longName": "PositionTrade",
+          "fullName": "vega.PositionTrade",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "volume",
+              "description": "Volume for the position trade, value is signed +ve for long and -ve for short",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price for the position trade, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Price",
+          "longName": "Price",
+          "fullName": "vega.Price",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "value",
+              "description": "Price value, given as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PriceLevel",
+          "longName": "PriceLevel",
+          "fullName": "vega.PriceLevel",
+          "description": "Represents a price level from market depth or order book data",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "price",
+              "description": "Price for the price level, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "number_of_orders",
+              "description": "Number of orders at the price level",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "volume",
+              "description": "Volume at the price level",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PriceMonitoringBounds",
+          "longName": "PriceMonitoringBounds",
+          "fullName": "vega.PriceMonitoringBounds",
+          "description": "Represents a list of valid (at the current timestamp) price ranges per associated trigger",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "min_valid_price",
+              "description": "Minimum price that isn't currently breaching the specified price monitoring trigger",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_valid_price",
+              "description": "Maximum price that isn't currently breaching the specified price monitoring trigger",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "Price monitoring trigger associated with the bounds",
+              "label": "",
+              "type": "PriceMonitoringTrigger",
+              "longType": "PriceMonitoringTrigger",
+              "fullType": "vega.PriceMonitoringTrigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference_price",
+              "description": "Reference price used to calculate the valid price range",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RiskFactor",
+          "longName": "RiskFactor",
+          "fullName": "vega.RiskFactor",
+          "description": "Risk factors are used to calculate the current risk associated with orders trading on a given market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market",
+              "description": "Market ID that relates to this risk factor",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "short",
+              "description": "Short Risk factor value",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "long",
+              "description": "Long Risk factor value",
+              "label": "",
+              "type": "double",
+              "longType": "double",
+              "fullType": "double",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RiskResult",
+          "longName": "RiskResult",
+          "fullName": "vega.RiskResult",
+          "description": "Risk results are calculated internally by Vega to attempt to maintain safe trading",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "updated_timestamp",
+              "description": "Timestamp for when risk factors were generated",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "risk_factors",
+              "description": "Risk factors (long and short) for each margin-able asset/currency (usually == settlement assets) in the market",
+              "label": "repeated",
+              "type": "RiskFactorsEntry",
+              "longType": "RiskResult.RiskFactorsEntry",
+              "fullType": "vega.RiskResult.RiskFactorsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "next_update_timestamp",
+              "description": "Timestamp for when risk factors are expected to change (or empty if risk factors are continually updated)",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "predicted_next_risk_factors",
+              "description": "Predicted risk factors at next change (what they would be if the change occurred now)",
+              "label": "repeated",
+              "type": "PredictedNextRiskFactorsEntry",
+              "longType": "RiskResult.PredictedNextRiskFactorsEntry",
+              "fullType": "vega.RiskResult.PredictedNextRiskFactorsEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PredictedNextRiskFactorsEntry",
+          "longName": "RiskResult.PredictedNextRiskFactorsEntry",
+          "fullName": "vega.RiskResult.PredictedNextRiskFactorsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "RiskFactor",
+              "longType": "RiskFactor",
+              "fullType": "vega.RiskFactor",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RiskFactorsEntry",
+          "longName": "RiskResult.RiskFactorsEntry",
+          "fullName": "vega.RiskResult.RiskFactorsEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "RiskFactor",
+              "longType": "RiskFactor",
+              "fullType": "vega.RiskFactor",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Signature",
+          "longName": "Signature",
+          "fullName": "vega.Signature",
+          "description": "A signature to be authenticate a transaction\nand to be verified by the vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "sig",
+              "description": "The bytes of the signature",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "algo",
+              "description": "The algorithm used to create the signature",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "The version of the signature used to create the signature",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SignedBundle",
+          "longName": "SignedBundle",
+          "fullName": "vega.SignedBundle",
+          "description": "A bundle of a transaction and it's signature",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tx",
+              "description": "Transaction payload (proto marshalled)",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sig",
+              "description": "The signature authenticating the transaction",
+              "label": "",
+              "type": "Signature",
+              "longType": "Signature",
+              "fullType": "vega.Signature",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Statistics",
+          "longName": "Statistics",
+          "fullName": "vega.Statistics",
+          "description": "Vega domain specific statistics as reported by the node the caller is connected to",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "block_height",
+              "description": "Current block height as reported by the Vega blockchain",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "backlog_length",
+              "description": "Current backlog length (number of transactions) that are waiting to be included in a block",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_peers",
+              "description": "Total number of connected peers to this node",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "genesis_time",
+              "description": "Genesis block date and time formatted in ISO-8601 datetime format with nanosecond precision",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "current_time",
+              "description": "Current system date and time formatted in ISO-8601 datetime format with nanosecond precision",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "vega_time",
+              "description": "Current Vega date and time formatted in ISO-8601 datetime format with nanosecond precision",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "Status of the connection to the Vega blockchain\n- See [`ChainStatus`](#vega.ChainStatus)",
+              "label": "",
+              "type": "ChainStatus",
+              "longType": "ChainStatus",
+              "fullType": "vega.ChainStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tx_per_block",
+              "description": "Transactions per block",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "average_tx_bytes",
+              "description": "Average transaction size in bytes",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "average_orders_per_block",
+              "description": "Average orders per block",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trades_per_second",
+              "description": "Trades emitted per second",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "orders_per_second",
+              "description": "Orders processed per second",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_markets",
+              "description": "Total markets on this Vega network",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_amend_order",
+              "description": "Total number of order amendments since genesis (on all markets)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_cancel_order",
+              "description": "Total number of order cancellations since genesis (on all markets)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_create_order",
+              "description": "Total number of order submissions since genesis (on all markets)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_orders",
+              "description": "Total number of orders processed since genesis (on all markets)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_trades",
+              "description": "Total number of trades emitted since genesis (on all markets)",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "order_subscriptions",
+              "description": "Current number of stream subscribers to order data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trade_subscriptions",
+              "description": "Current number of stream subscribers to trade data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "candle_subscriptions",
+              "description": "Current number of stream subscribers to candle-stick data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_depth_subscriptions",
+              "description": "Current number of stream subscribers to market depth data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "positions_subscriptions",
+              "description": "Current number of stream subscribers to positions data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "account_subscriptions",
+              "description": "Current number of stream subscribers to account data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_data_subscriptions",
+              "description": "Current number of stream subscribers to market data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "app_version_hash",
+              "description": "The version hash of the Vega node software",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "app_version",
+              "description": "The version of the Vega node software",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chain_version",
+              "description": "The version of the underlying Vega blockchain",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "block_duration",
+              "description": "Current block duration, in nanoseconds",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "uptime",
+              "description": "Total uptime for this node formatted in ISO-8601 datetime format with nanosecond precision",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chain_id",
+              "description": "Unique identifier for the underlying Vega blockchain",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_depth_updates_subscriptions",
+              "description": "Current number of stream subscribers to market depth update data",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Timestamp",
+          "longName": "Timestamp",
+          "fullName": "vega.Timestamp",
+          "description": "A timestamp in nanoseconds since epoch\nSee [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "value",
+              "description": "Timestamp value",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Trade",
+          "longName": "Trade",
+          "fullName": "vega.Trade",
+          "description": "A trade occurs when an aggressive order crosses one or more passive orders on the order book for a market on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier for the trade (generated by Vega)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier (the market that the trade occurred on)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price for the trade, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size",
+              "description": "Size filled for the trade",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buyer",
+              "description": "Unique party identifier for the buyer",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seller",
+              "description": "Unique party identifier for the seller",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "aggressor",
+              "description": "Direction of the aggressive party e.g. SIDE_BUY or SIDE_SELL - See [`Side`](#vega.Side)",
+              "label": "",
+              "type": "Side",
+              "longType": "Side",
+              "fullType": "vega.Side",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buy_order",
+              "description": "Identifier of the order from the buy side",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sell_order",
+              "description": "Identifier of the order from the sell side",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "timestamp",
+              "description": "Timestamp for when the trade occurred, in nanoseconds since the epoch\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type for the trade - See [`Trade.Type`](#vega.Trade.Type)",
+              "label": "",
+              "type": "Type",
+              "longType": "Trade.Type",
+              "fullType": "vega.Trade.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buyer_fee",
+              "description": "Fee amount charged to the buyer party for the trade",
+              "label": "",
+              "type": "Fee",
+              "longType": "Fee",
+              "fullType": "vega.Fee",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seller_fee",
+              "description": "Fee amount charged to the seller party for the trade",
+              "label": "",
+              "type": "Fee",
+              "longType": "Fee",
+              "fullType": "vega.Fee",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buyer_auction_batch",
+              "description": "Auction batch number that the buy side order was placed in",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "seller_auction_batch",
+              "description": "Auction batch number that the sell side order was placed in",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradeSet",
+          "longName": "TradeSet",
+          "fullName": "vega.TradeSet",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trades",
+              "description": "A set of one or more trades",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Transaction",
+          "longName": "Transaction",
+          "fullName": "vega.Transaction",
+          "description": "Represents a transaction to be sent to Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "input_data",
+              "description": "One of the set of Vega commands (proto marshalled)",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "nonce",
+              "description": "A random number used to provide uniqueness and prevent against replay attack",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "block_height",
+              "description": "The block height associated to the transaction, this should always be current block height\nof the node at the time of sending the Tx and block height is used as a mechanism\nfor replay protection",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "address",
+              "description": "The address of the sender",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "from",
+              "defaultValue": ""
+            },
+            {
+              "name": "pub_key",
+              "description": "The public key of the sender",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "from",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Transfer",
+          "longName": "Transfer",
+          "fullName": "vega.Transfer",
+          "description": "Represents a financial transfer within Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "owner",
+              "description": "Party identifier for the owner of the transfer",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "A financial amount (of an asset) to transfer",
+              "label": "",
+              "type": "FinancialAmount",
+              "longType": "FinancialAmount",
+              "fullType": "vega.FinancialAmount",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "The type of transfer, gives the reason for the transfer",
+              "label": "",
+              "type": "TransferType",
+              "longType": "TransferType",
+              "fullType": "vega.TransferType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_amount",
+              "description": "A minimum amount",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransferBalance",
+          "longName": "TransferBalance",
+          "fullName": "vega.TransferBalance",
+          "description": "Represents the balance for an account during a transfer",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "account",
+              "description": "The account relating to the transfer",
+              "label": "",
+              "type": "Account",
+              "longType": "Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "balance",
+              "description": "The balance relating to the transfer",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransferRequest",
+          "longName": "TransferRequest",
+          "fullName": "vega.TransferRequest",
+          "description": "Represents a request to transfer from one set of accounts to another",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "from_account",
+              "description": "One or more accounts to transfer from",
+              "label": "repeated",
+              "type": "Account",
+              "longType": "Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "to_account",
+              "description": "One or more accounts to transfer to",
+              "label": "repeated",
+              "type": "Account",
+              "longType": "Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "An amount to transfer for the asset",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "min_amount",
+              "description": "A minimum amount",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "A reference for auditing purposes",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransferResponse",
+          "longName": "TransferResponse",
+          "fullName": "vega.TransferResponse",
+          "description": "Represents the response from a transfer",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "transfers",
+              "description": "One or more ledger entries representing the transfers",
+              "label": "repeated",
+              "type": "LedgerEntry",
+              "longType": "LedgerEntry",
+              "fullType": "vega.LedgerEntry",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "balances",
+              "description": "One or more account balances",
+              "label": "repeated",
+              "type": "TransferBalance",
+              "longType": "TransferBalance",
+              "fullType": "vega.TransferBalance",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WithdrawExt",
+          "longName": "WithdrawExt",
+          "fullName": "vega.WithdrawExt",
+          "description": "Withdrawal external details",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "erc20",
+              "description": "ERC20 withdrawal details",
+              "label": "",
+              "type": "Erc20WithdrawExt",
+              "longType": "Erc20WithdrawExt",
+              "fullType": "vega.Erc20WithdrawExt",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "ext",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Withdrawal",
+          "longName": "Withdrawal",
+          "fullName": "vega.Withdrawal",
+          "description": "A withdrawal from the Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique identifier for the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Unique party identifier of the user initiating the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be withdrawn",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "The asset we want to withdraw funds from",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "status",
+              "description": "The status of the withdrawal",
+              "label": "",
+              "type": "Status",
+              "longType": "Withdrawal.Status",
+              "fullType": "vega.Withdrawal.Status",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ref",
+              "description": "The reference which is used by the foreign chain\nto refer to this withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expiry",
+              "description": "The time until when the withdrawal is valid",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "tx_hash",
+              "description": "The hash of the foreign chain for this transaction",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "created_timestamp",
+              "description": "Timestamp for when the network started to process this withdrawal",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdrawn_timestamp",
+              "description": "Timestamp for when the withdrawal was finalised by the network",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ext",
+              "description": "Foreign chain specifics",
+              "label": "",
+              "type": "WithdrawExt",
+              "longType": "WithdrawExt",
+              "fullType": "vega.WithdrawExt",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "assets.proto",
+      "description": "",
+      "package": "vega",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Asset",
+          "longName": "Asset",
+          "fullName": "vega.Asset",
+          "description": "The Vega representation of an external asset",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "Name of the asset (e.g: Great British Pound)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "symbol",
+              "description": "Symbol of the asset (e.g: GBP)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_supply",
+              "description": "Total circulating supply for the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "decimals",
+              "description": "Number of decimals / precision handled by this asset",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "source",
+              "description": "The definition of the external source for this asset",
+              "label": "",
+              "type": "AssetSource",
+              "longType": "AssetSource",
+              "fullType": "vega.AssetSource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AssetSource",
+          "longName": "AssetSource",
+          "fullName": "vega.AssetSource",
+          "description": "Asset source definition",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "builtin_asset",
+              "description": "A built-in asset",
+              "label": "",
+              "type": "BuiltinAsset",
+              "longType": "BuiltinAsset",
+              "fullType": "vega.BuiltinAsset",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "source",
+              "defaultValue": ""
+            },
+            {
+              "name": "erc20",
+              "description": "An Ethereum ERC20 asset",
+              "label": "",
+              "type": "ERC20",
+              "longType": "ERC20",
+              "fullType": "vega.ERC20",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "source",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BuiltinAsset",
+          "longName": "BuiltinAsset",
+          "fullName": "vega.BuiltinAsset",
+          "description": "A Vega internal asset",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "Name of the asset (e.g: Great British Pound)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "symbol",
+              "description": "Symbol of the asset (e.g: GBP)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_supply",
+              "description": "Total circulating supply for the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "decimals",
+              "description": "Number of decimal / precision handled by this asset",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_faucet_amount_mint",
+              "description": "Maximum amount that can be requested by a party through the built-in asset faucet at a time",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20",
+          "longName": "ERC20",
+          "fullName": "vega.ERC20",
+          "description": "An ERC20 token based asset, living on the ethereum network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "contract_address",
+              "description": "The address of the contract for the token, on the ethereum network",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "governance.proto",
+      "description": "",
+      "package": "vega",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "State",
+          "longName": "Proposal.State",
+          "fullName": "vega.Proposal.State",
+          "description": "Proposal state transition:\nOpen -\u003e\n  - Passed -\u003e Enacted.\n  - Passed -\u003e Failed.\n  - Declined\nRejected\nProposal can enter Failed state from any other state",
+          "values": [
+            {
+              "name": "STATE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "STATE_FAILED",
+              "number": "1",
+              "description": "Proposal enactment has failed - even though proposal has passed, its execution could not be performed"
+            },
+            {
+              "name": "STATE_OPEN",
+              "number": "2",
+              "description": "Proposal is open for voting"
+            },
+            {
+              "name": "STATE_PASSED",
+              "number": "3",
+              "description": "Proposal has gained enough support to be executed"
+            },
+            {
+              "name": "STATE_REJECTED",
+              "number": "4",
+              "description": "Proposal wasn't accepted (proposal terms failed validation due to wrong configuration or failing to meet network requirements)"
+            },
+            {
+              "name": "STATE_DECLINED",
+              "number": "5",
+              "description": "Proposal didn't get enough votes (either failing to gain required participation or majority level)"
+            },
+            {
+              "name": "STATE_ENACTED",
+              "number": "6",
+              "description": "Proposal enacted"
+            },
+            {
+              "name": "STATE_WAITING_FOR_NODE_VOTE",
+              "number": "7",
+              "description": "Waiting for node validation of the proposal"
+            }
+          ]
+        },
+        {
+          "name": "ProposalError",
+          "longName": "ProposalError",
+          "fullName": "vega.ProposalError",
+          "description": "A list of possible errors that can cause a proposal to be in state rejected or failed",
+          "values": [
+            {
+              "name": "PROPOSAL_ERROR_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value"
+            },
+            {
+              "name": "PROPOSAL_ERROR_CLOSE_TIME_TOO_SOON",
+              "number": "1",
+              "description": "The specified close time is too early base on network parameters"
+            },
+            {
+              "name": "PROPOSAL_ERROR_CLOSE_TIME_TOO_LATE",
+              "number": "2",
+              "description": "The specified close time is too late based on network parameters"
+            },
+            {
+              "name": "PROPOSAL_ERROR_ENACT_TIME_TOO_SOON",
+              "number": "3",
+              "description": "The specified enact time is too early based on network parameters"
+            },
+            {
+              "name": "PROPOSAL_ERROR_ENACT_TIME_TOO_LATE",
+              "number": "4",
+              "description": "The specified enact time is too late based on network parameters"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INSUFFICIENT_TOKENS",
+              "number": "5",
+              "description": "The proposer for this proposal as insufficient tokens"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_INSTRUMENT_SECURITY",
+              "number": "6",
+              "description": "The instrument quote name and base name were the same"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NO_PRODUCT",
+              "number": "7",
+              "description": "The proposal has no product"
+            },
+            {
+              "name": "PROPOSAL_ERROR_UNSUPPORTED_PRODUCT",
+              "number": "8",
+              "description": "The specified product is not supported"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_FUTURE_PRODUCT_TIMESTAMP",
+              "number": "9",
+              "description": "Invalid future maturity timestamp (expect RFC3339)"
+            },
+            {
+              "name": "PROPOSAL_ERROR_PRODUCT_MATURITY_IS_PASSED",
+              "number": "10",
+              "description": "The product maturity is past"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NO_TRADING_MODE",
+              "number": "11",
+              "description": "The proposal has no trading mode"
+            },
+            {
+              "name": "PROPOSAL_ERROR_UNSUPPORTED_TRADING_MODE",
+              "number": "12",
+              "description": "The proposal has an unsupported trading mode"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NODE_VALIDATION_FAILED",
+              "number": "13",
+              "description": "The proposal failed node validation"
+            },
+            {
+              "name": "PROPOSAL_ERROR_MISSING_BUILTIN_ASSET_FIELD",
+              "number": "14",
+              "description": "A field is missing in a builtin asset source"
+            },
+            {
+              "name": "PROPOSAL_ERROR_MISSING_ERC20_CONTRACT_ADDRESS",
+              "number": "15",
+              "description": "The contract address is missing in the ERC20 asset source"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_ASSET",
+              "number": "16",
+              "description": "The asset identifier is invalid or does not exist on the Vega network"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INCOMPATIBLE_TIMESTAMPS",
+              "number": "17",
+              "description": "Proposal terms timestamps are not compatible (Validation \u003c Closing \u003c Enactment)"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NO_RISK_PARAMETERS",
+              "number": "18",
+              "description": "No risk parameters were specified"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NETWORK_PARAMETER_INVALID_KEY",
+              "number": "19",
+              "description": "Invalid key in update network parameter proposal"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NETWORK_PARAMETER_INVALID_VALUE",
+              "number": "20",
+              "description": "Invalid valid in update network parameter proposal"
+            },
+            {
+              "name": "PROPOSAL_ERROR_NETWORK_PARAMETER_VALIDATION_FAILED",
+              "number": "21",
+              "description": "Validation failed for network parameter proposal"
+            },
+            {
+              "name": "PROPOSAL_ERROR_OPENING_AUCTION_DURATION_TOO_SMALL",
+              "number": "22",
+              "description": "Opening auction duration is less than the network minimum opening auction time"
+            },
+            {
+              "name": "PROPOSAL_ERROR_OPENING_AUCTION_DURATION_TOO_LARGE",
+              "number": "23",
+              "description": "Opening auction duration is more than the network minimum opening auction time"
+            },
+            {
+              "name": "PROPOSAL_ERROR_MARKET_MISSING_LIQUIDITY_COMMITMENT",
+              "number": "24",
+              "description": "Market proposal is missing a liquidity commitment"
+            },
+            {
+              "name": "PROPOSAL_ERROR_COULD_NOT_INSTANTIATE_MARKET",
+              "number": "25",
+              "description": "Market proposal market could not be instantiate in execution"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_FUTURE_PRODUCT",
+              "number": "26",
+              "description": "Market proposal market contained invalid product definition"
+            },
+            {
+              "name": "PROPOSAL_ERROR_MISSING_COMMITMENT_AMOUNT",
+              "number": "27",
+              "description": "Market proposal is missing commitment amount"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_FEE_AMOUNT",
+              "number": "28",
+              "description": "Market proposal have invalid fee"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_SHAPE",
+              "number": "29",
+              "description": "Market proposal have invalid shape"
+            },
+            {
+              "name": "PROPOSAL_ERROR_INVALID_RISK_PARAMETER",
+              "number": "30",
+              "description": "Market proposal invalid risk parameter"
+            }
+          ]
+        },
+        {
+          "name": "Value",
+          "longName": "Vote.Value",
+          "fullName": "vega.Vote.Value",
+          "description": "Vote value",
+          "values": [
+            {
+              "name": "VALUE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "VALUE_NO",
+              "number": "1",
+              "description": "A vote against the proposal"
+            },
+            {
+              "name": "VALUE_YES",
+              "number": "2",
+              "description": "A vote in favour of the proposal"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "FutureProduct",
+          "longName": "FutureProduct",
+          "fullName": "vega.FutureProduct",
+          "description": "Future product configuration",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "maturity",
+              "description": "Future product maturity (ISO8601/RFC3339 timestamp)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "settlement_asset",
+              "description": "Product settlement asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "quote_name",
+              "description": "Product quote name",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "oracle_spec",
+              "description": "The oracle spec describing the oracle data of interest",
+              "label": "",
+              "type": "OracleSpecConfiguration",
+              "longType": "oracles.v1.OracleSpecConfiguration",
+              "fullType": "oracles.v1.OracleSpecConfiguration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "oracle_spec_binding",
+              "description": "The binding between the oracle spec and the settlement price",
+              "label": "",
+              "type": "OracleSpecToFutureBinding",
+              "longType": "OracleSpecToFutureBinding",
+              "fullType": "vega.OracleSpecToFutureBinding",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GovernanceData",
+          "longName": "GovernanceData",
+          "fullName": "vega.GovernanceData",
+          "description": "Governance data",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "proposal",
+              "description": "The governance proposal",
+              "label": "",
+              "type": "Proposal",
+              "longType": "Proposal",
+              "fullType": "vega.Proposal",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "yes",
+              "description": "All \"yes\" votes in favour of the proposal above",
+              "label": "repeated",
+              "type": "Vote",
+              "longType": "Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "no",
+              "description": "All \"no\" votes against the proposal above",
+              "label": "repeated",
+              "type": "Vote",
+              "longType": "Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "yes_party",
+              "description": "All latest YES votes by party (guaranteed to be unique),\nwhere key (string) is the party ID (public key) and\nvalue (Vote) is the vote cast by the given party",
+              "label": "repeated",
+              "type": "YesPartyEntry",
+              "longType": "GovernanceData.YesPartyEntry",
+              "fullType": "vega.GovernanceData.YesPartyEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "no_party",
+              "description": "All latest NO votes by party (guaranteed to be unique),\nwhere key (string) is the party ID (public key) and\nvalue (Vote) is the vote cast by the given party",
+              "label": "repeated",
+              "type": "NoPartyEntry",
+              "longType": "GovernanceData.NoPartyEntry",
+              "fullType": "vega.GovernanceData.NoPartyEntry",
+              "ismap": true,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NoPartyEntry",
+          "longName": "GovernanceData.NoPartyEntry",
+          "fullName": "vega.GovernanceData.NoPartyEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Vote",
+              "longType": "Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "YesPartyEntry",
+          "longName": "GovernanceData.YesPartyEntry",
+          "fullName": "vega.GovernanceData.YesPartyEntry",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "Vote",
+              "longType": "Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "InstrumentConfiguration",
+          "longName": "InstrumentConfiguration",
+          "fullName": "vega.InstrumentConfiguration",
+          "description": "Instrument configuration",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "Instrument name",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "code",
+              "description": "Instrument code",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "future",
+              "description": "Future",
+              "label": "",
+              "type": "FutureProduct",
+              "longType": "FutureProduct",
+              "fullType": "vega.FutureProduct",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "product",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NewAsset",
+          "longName": "NewAsset",
+          "fullName": "vega.NewAsset",
+          "description": "New asset on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "changes",
+              "description": "The configuration of the new asset",
+              "label": "",
+              "type": "AssetSource",
+              "longType": "AssetSource",
+              "fullType": "vega.AssetSource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "NewMarket",
+          "longName": "NewMarket",
+          "fullName": "vega.NewMarket",
+          "description": "New market on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "changes",
+              "description": "The configuration of the new market",
+              "label": "",
+              "type": "NewMarketConfiguration",
+              "longType": "NewMarketConfiguration",
+              "fullType": "vega.NewMarketConfiguration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "liquidity_commitment",
+              "description": "The commitment from the party creating the NewMarket proposal",
+              "label": "",
+              "type": "NewMarketCommitment",
+              "longType": "NewMarketCommitment",
+              "fullType": "vega.NewMarketCommitment",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NewMarketCommitment",
+          "longName": "NewMarketCommitment",
+          "fullName": "vega.NewMarketCommitment",
+          "description": "A commitment of liquidity to be made by the party which proposes a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "commitment_amount",
+              "description": "Specified as a unitless number that represents the amount of settlement asset of the market",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "fee",
+              "description": "Nominated liquidity fee factor, which is an input to the calculation of taker fees on the market, as per seeting fees and rewarding liquidity providers",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sells",
+              "description": "A set of liquidity sell orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrder",
+              "longType": "LiquidityOrder",
+              "fullType": "vega.LiquidityOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buys",
+              "description": "A set of liquidity buy orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrder",
+              "longType": "LiquidityOrder",
+              "fullType": "vega.LiquidityOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "A reference to be associated to all orders created from this commitment",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NewMarketConfiguration",
+          "longName": "NewMarketConfiguration",
+          "fullName": "vega.NewMarketConfiguration",
+          "description": "Configuration for a new market on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "instrument",
+              "description": "New market instrument configuration",
+              "label": "",
+              "type": "InstrumentConfiguration",
+              "longType": "InstrumentConfiguration",
+              "fullType": "vega.InstrumentConfiguration",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "decimal_places",
+              "description": "Decimal places used for the new market",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_lt",
+                    "value": 150
+                  }
+                ]
+              }
+            },
+            {
+              "name": "metadata",
+              "description": "Optional new market meta data, tags",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price_monitoring_parameters",
+              "description": "Price monitoring parameters",
+              "label": "",
+              "type": "PriceMonitoringParameters",
+              "longType": "PriceMonitoringParameters",
+              "fullType": "vega.PriceMonitoringParameters",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_monitoring_parameters",
+              "description": "Liquidity monitoring parameters",
+              "label": "",
+              "type": "LiquidityMonitoringParameters",
+              "longType": "LiquidityMonitoringParameters",
+              "fullType": "vega.LiquidityMonitoringParameters",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "simple",
+              "description": "Simple risk model parameters, valid only if MODEL_SIMPLE is selected",
+              "label": "",
+              "type": "SimpleModelParams",
+              "longType": "SimpleModelParams",
+              "fullType": "vega.SimpleModelParams",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "risk_parameters",
+              "defaultValue": ""
+            },
+            {
+              "name": "log_normal",
+              "description": "Log normal risk model parameters, valid only if MODEL_LOG_NORMAL is selected",
+              "label": "",
+              "type": "LogNormalRiskModel",
+              "longType": "LogNormalRiskModel",
+              "fullType": "vega.LogNormalRiskModel",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "risk_parameters",
+              "defaultValue": ""
+            },
+            {
+              "name": "continuous",
+              "description": "Continuous trading",
+              "label": "",
+              "type": "ContinuousTrading",
+              "longType": "ContinuousTrading",
+              "fullType": "vega.ContinuousTrading",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "trading_mode",
+              "defaultValue": ""
+            },
+            {
+              "name": "discrete",
+              "description": "Discrete trading",
+              "label": "",
+              "type": "DiscreteTrading",
+              "longType": "DiscreteTrading",
+              "fullType": "vega.DiscreteTrading",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "trading_mode",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Proposal",
+          "longName": "Proposal",
+          "fullName": "vega.Proposal",
+          "description": "Governance proposal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Unique proposal identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "Proposal reference",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier of the author (the party submitting the proposal)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "state",
+              "description": "Proposal state - See (Proposal.State)[#vega.Proposal.State] definition",
+              "label": "",
+              "type": "State",
+              "longType": "Proposal.State",
+              "fullType": "vega.Proposal.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": null
+              }
+            },
+            {
+              "name": "timestamp",
+              "description": "Proposal timestamp for date and time (in nanoseconds) when proposal was submitted to the network",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "terms",
+              "description": "Proposal configuration and the actual change that is meant to be executed when proposal is enacted",
+              "label": "",
+              "type": "ProposalTerms",
+              "longType": "ProposalTerms",
+              "fullType": "vega.ProposalTerms",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reason",
+              "description": "A reason for the current state of the proposal, this may be set in case of REJECTED and FAILED statuses",
+              "label": "",
+              "type": "ProposalError",
+              "longType": "ProposalError",
+              "fullType": "vega.ProposalError",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ProposalTerms",
+          "longName": "ProposalTerms",
+          "fullName": "vega.ProposalTerms",
+          "description": "Terms for a governance proposal on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "closing_timestamp",
+              "description": "Timestamp (Unix time in seconds) when voting closes for this proposal,\nconstrained by `minCloseInSeconds` and `maxCloseInSeconds` network parameters",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "enactment_timestamp",
+              "description": "Timestamp (Unix time in seconds) when proposal gets enacted (if passed),\nconstrained by `minEnactInSeconds` and `maxEnactInSeconds` network parameters",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "validation_timestamp",
+              "description": "Validation timestamp (Unix time in seconds)",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "update_market",
+              "description": "Proposal change for modifying an existing market on Vega",
+              "label": "",
+              "type": "UpdateMarket",
+              "longType": "UpdateMarket",
+              "fullType": "vega.UpdateMarket",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "change",
+              "defaultValue": ""
+            },
+            {
+              "name": "new_market",
+              "description": "Proposal change for creating new market on Vega",
+              "label": "",
+              "type": "NewMarket",
+              "longType": "NewMarket",
+              "fullType": "vega.NewMarket",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "change",
+              "defaultValue": ""
+            },
+            {
+              "name": "update_network_parameter",
+              "description": "Proposal change for updating Vega network parameters",
+              "label": "",
+              "type": "UpdateNetworkParameter",
+              "longType": "UpdateNetworkParameter",
+              "fullType": "vega.UpdateNetworkParameter",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "change",
+              "defaultValue": ""
+            },
+            {
+              "name": "new_asset",
+              "description": "Proposal change for creating new assets on Vega",
+              "label": "",
+              "type": "NewAsset",
+              "longType": "NewAsset",
+              "fullType": "vega.NewAsset",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "change",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "UpdateMarket",
+          "longName": "UpdateMarket",
+          "fullName": "vega.UpdateMarket",
+          "description": "Update an existing market on Vega",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "UpdateNetworkParameter",
+          "longName": "UpdateNetworkParameter",
+          "fullName": "vega.UpdateNetworkParameter",
+          "description": "Update network configuration on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "changes",
+              "description": "The network parameter to update",
+              "label": "",
+              "type": "NetworkParameter",
+              "longType": "NetworkParameter",
+              "fullType": "vega.NetworkParameter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Vote",
+          "longName": "Vote",
+          "fullName": "vega.Vote",
+          "description": "Governance vote",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Voter's party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "value",
+              "description": "Actual vote",
+              "label": "",
+              "type": "Value",
+              "longType": "Vote.Value",
+              "fullType": "vega.Vote.Value",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": null
+              }
+            },
+            {
+              "name": "proposal_id",
+              "description": "Identifier of the proposal being voted on",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "timestamp",
+              "description": "Vote timestamp for date and time (in nanoseconds) when vote was submitted to the network",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_governance_token_balance",
+              "description": "Total number of governance token for the party that casted the vote",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_governance_token_weight",
+              "description": "The weight of this vote based on the total of governance token",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "oracles/v1/oracle_data.proto",
+      "description": "",
+      "package": "oracles.v1",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "OracleData",
+          "longName": "OracleData",
+          "fullName": "oracles.v1.OracleData",
+          "description": "OracleData describes an oracle data that has been broadcast.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_keys",
+              "description": "pubKeys is the list of authorized public keys that signed the data for this\noracle. All the public keys in the oracle data should be contained in these\npublic keys.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "data holds all the properties of the oracle data",
+              "label": "repeated",
+              "type": "Property",
+              "longType": "Property",
+              "fullType": "oracles.v1.Property",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "matched_spec_ids",
+              "description": "matched_specs_ids lists all the oracle specs that matched this oracle data.",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "broadcast_at",
+              "description": "broadcast_at is the time at which the data was broadcast for the first\ntime.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Property",
+          "longName": "Property",
+          "fullName": "oracles.v1.Property",
+          "description": "Property describes one property of an oracle spec with a key with its value.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "name",
+              "description": "name is the name of the property.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "value is the value of the property.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "commands/v1/commands.proto",
+      "description": "",
+      "package": "vega.commands.v1",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "LiquidityProvisionSubmission",
+          "longName": "LiquidityProvisionSubmission",
+          "fullName": "vega.commands.v1.LiquidityProvisionSubmission",
+          "description": "A liquidity provision submitted for a given market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the order, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "commitment_amount",
+              "description": "Specified as a unitless number that represents the amount of settlement asset of the market",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "fee",
+              "description": "Nominated liquidity fee factor, which is an input to the calculation of taker fees on the market, as per seeting fees and rewarding liquidity providers",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sells",
+              "description": "A set of liquidity sell orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrder",
+              "longType": "vega.LiquidityOrder",
+              "fullType": "vega.LiquidityOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buys",
+              "description": "A set of liquidity buy orders to meet the liquidity provision obligation",
+              "label": "repeated",
+              "type": "LiquidityOrder",
+              "longType": "vega.LiquidityOrder",
+              "fullType": "vega.LiquidityOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "A reference to be added to every order created out of this liquidityProvisionSubmission",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderAmendment",
+          "longName": "OrderAmendment",
+          "fullName": "vega.commands.v1.OrderAmendment",
+          "description": "An order amendment is a request to amend or update an existing order on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Order identifier, this is required to find the order and will not be updated, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier, this is required to find the order and will not be updated",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Amend the price for the order, if the Price value is set, otherwise price will remain unchanged - See [`Price`](#vega.Price)",
+              "label": "",
+              "type": "Price",
+              "longType": "vega.Price",
+              "fullType": "vega.Price",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size_delta",
+              "description": "Amend the size for the order by the delta specified:\n- To reduce the size from the current value set a negative integer value\n- To increase the size from the current value, set a positive integer value\n- To leave the size unchanged set a value of zero",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expires_at",
+              "description": "Amend the expiry time for the order, if the Timestamp value is set, otherwise expiry time will remain unchanged\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "Timestamp",
+              "longType": "vega.Timestamp",
+              "fullType": "vega.Timestamp",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time_in_force",
+              "description": "Amend the time in force for the order, set to TIME_IN_FORCE_UNSPECIFIED to remain unchanged\n- See [`TimeInForce`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "TimeInForce",
+              "longType": "vega.Order.TimeInForce",
+              "fullType": "vega.Order.TimeInForce",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pegged_offset",
+              "description": "Amend the pegged order offset for the order",
+              "label": "",
+              "type": "Int64Value",
+              "longType": "google.protobuf.Int64Value",
+              "fullType": "google.protobuf.Int64Value",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pegged_reference",
+              "description": "Amend the pegged order reference for the order\n- See [`PeggedReference`](#vega.PeggedReference)",
+              "label": "",
+              "type": "PeggedReference",
+              "longType": "vega.PeggedReference",
+              "fullType": "vega.PeggedReference",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderCancellation",
+          "longName": "OrderCancellation",
+          "fullName": "vega.commands.v1.OrderCancellation",
+          "description": "An order cancellation is a request to cancel an existing order on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Unique identifier for the order (set by the system after consensus), required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier for the order, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderSubmission",
+          "longName": "OrderSubmission",
+          "fullName": "vega.commands.v1.OrderSubmission",
+          "description": "An order submission is a request to submit or create a new order on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the order, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "price",
+              "description": "Price for the order, the price is an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places,\n, required field for limit orders, however it is not required for market orders",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "size",
+              "description": "Size for the order, for example, in a futures market the size equals the number of contracts, cannot be negative",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "side",
+              "description": "Side for the order, e.g. SIDE_BUY or SIDE_SELL, required field - See [`Side`](#vega.Side)",
+              "label": "",
+              "type": "Side",
+              "longType": "vega.Side",
+              "fullType": "vega.Side",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time_in_force",
+              "description": "Time in force indicates how long an order will remain active before it is executed or expires, required field\n- See [`Order.TimeInForce`](#vega.Order.TimeInForce)",
+              "label": "",
+              "type": "TimeInForce",
+              "longType": "vega.Order.TimeInForce",
+              "fullType": "vega.Order.TimeInForce",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expires_at",
+              "description": "Timestamp for when the order will expire, in nanoseconds since the epoch,\nrequired field only for [`Order.TimeInForce`](#vega.Order.TimeInForce)`.TIME_IN_FORCE_GTT`\n- See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type for the order, required field - See [`Order.Type`](#vega.Order.Type)",
+              "label": "",
+              "type": "Type",
+              "longType": "vega.Order.Type",
+              "fullType": "vega.Order.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference",
+              "description": "Reference given for the order, this is typically used to retrieve an order submitted through consensus, currently\nset internally by the node to return a unique reference identifier for the order submission",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pegged_order",
+              "description": "Used to specify the details for a pegged order\n- See [`PeggedOrder`](#vega.PeggedOrder)",
+              "label": "",
+              "type": "PeggedOrder",
+              "longType": "vega.PeggedOrder",
+              "fullType": "vega.PeggedOrder",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ProposalSubmission",
+          "longName": "ProposalSubmission",
+          "fullName": "vega.commands.v1.ProposalSubmission",
+          "description": "A command to submit a new proposal for the\nvega network governance",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "reference",
+              "description": "Proposal reference",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "terms",
+              "description": "Proposal configuration and the actual change that is meant to be executed when proposal is enacted",
+              "label": "",
+              "type": "ProposalTerms",
+              "longType": "vega.ProposalTerms",
+              "fullType": "vega.ProposalTerms",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "VoteSubmission",
+          "longName": "VoteSubmission",
+          "fullName": "vega.commands.v1.VoteSubmission",
+          "description": "A command to submit a new vote for a governance\nproposal.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "proposal_id",
+              "description": "The ID of the proposal to vote for.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "value",
+              "description": "The actual value of the vote",
+              "label": "",
+              "type": "Value",
+              "longType": "vega.Vote.Value",
+              "fullType": "vega.Vote.Value",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WithdrawSubmission",
+          "longName": "WithdrawSubmission",
+          "fullName": "vega.commands.v1.WithdrawSubmission",
+          "description": "Represents the submission request to withdraw funds for a party on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "amount",
+              "description": "The amount to be withdrawn",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "The asset we want to withdraw",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "ext",
+              "description": "Foreign chain specifics",
+              "label": "",
+              "type": "WithdrawExt",
+              "longType": "vega.WithdrawExt",
+              "fullType": "vega.WithdrawExt",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "chain_events.proto",
+      "description": "",
+      "package": "vega",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "AddValidator",
+          "longName": "AddValidator",
+          "fullName": "vega.AddValidator",
+          "description": "A message to notify when a new validator is being added to the Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The identifier of the validator",
+              "label": "",
+              "type": "Identifier",
+              "longType": "Identifier",
+              "fullType": "vega.Identifier",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BTCDeposit",
+          "longName": "BTCDeposit",
+          "fullName": "vega.BTCDeposit",
+          "description": "A Bitcoin deposit into Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The Vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "source_btc_address",
+              "description": "The BTC wallet initiating the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "target_party_id",
+              "description": "The Vega party identifier (pub-key) which is the target of the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BTCEvent",
+          "longName": "BTCEvent",
+          "fullName": "vega.BTCEvent",
+          "description": "An event from the Bitcoin network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "index",
+              "description": "The index of the transaction",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "block",
+              "description": "The block in which the transaction happened",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "deposit",
+              "description": "Deposit BTC asset",
+              "label": "",
+              "type": "BTCDeposit",
+              "longType": "BTCDeposit",
+              "fullType": "vega.BTCDeposit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdrawal",
+              "description": "Withdraw BTC asset",
+              "label": "",
+              "type": "BTCWithdrawal",
+              "longType": "BTCWithdrawal",
+              "fullType": "vega.BTCWithdrawal",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BTCWithdrawal",
+          "longName": "BTCWithdrawal",
+          "fullName": "vega.BTCWithdrawal",
+          "description": "A Bitcoin withdrawal from Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "source_party_id",
+              "description": "The party identifier (pub-key) initiating the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "target_btc_address",
+              "description": "Target Bitcoin wallet address",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference_nonce",
+              "description": "The nonce reference of the transaction",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BitcoinAddress",
+          "longName": "BitcoinAddress",
+          "fullName": "vega.BitcoinAddress",
+          "description": "Used as a wrapper for a Bitcoin address (wallet)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "address",
+              "description": "A Bitcoin address",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BuiltinAssetDeposit",
+          "longName": "BuiltinAssetDeposit",
+          "fullName": "vega.BuiltinAssetDeposit",
+          "description": "A deposit for a Vega built-in asset",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "A Vega network internal asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "A Vega party identifier (pub-key)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be deposited",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BuiltinAssetEvent",
+          "longName": "BuiltinAssetEvent",
+          "fullName": "vega.BuiltinAssetEvent",
+          "description": "An event related to a Vega built-in asset",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "deposit",
+              "description": "Built-in asset deposit",
+              "label": "",
+              "type": "BuiltinAssetDeposit",
+              "longType": "BuiltinAssetDeposit",
+              "fullType": "vega.BuiltinAssetDeposit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdrawal",
+              "description": "Built-in asset withdrawal",
+              "label": "",
+              "type": "BuiltinAssetWithdrawal",
+              "longType": "BuiltinAssetWithdrawal",
+              "fullType": "vega.BuiltinAssetWithdrawal",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BuiltinAssetWithdrawal",
+          "longName": "BuiltinAssetWithdrawal",
+          "fullName": "vega.BuiltinAssetWithdrawal",
+          "description": "A withdrawal for a Vega built-in asset",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "A Vega network internal asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "A Vega network party identifier (pub-key)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be withdrawn",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20AssetDelist",
+          "longName": "ERC20AssetDelist",
+          "fullName": "vega.ERC20AssetDelist",
+          "description": "An asset deny-listing for an ERC20 token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The Vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20AssetList",
+          "longName": "ERC20AssetList",
+          "fullName": "vega.ERC20AssetList",
+          "description": "An asset allow-listing for an ERC20 token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The Vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20Deposit",
+          "longName": "ERC20Deposit",
+          "fullName": "vega.ERC20Deposit",
+          "description": "An asset deposit for an ERC20 token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "source_ethereum_address",
+              "description": "The Ethereum wallet that initiated the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "target_party_id",
+              "description": "The Vega party identifier (pub-key) which is the target of the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be deposited",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20Event",
+          "longName": "ERC20Event",
+          "fullName": "vega.ERC20Event",
+          "description": "An event related to an ERC20 token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "index",
+              "description": "Index of the transaction",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "block",
+              "description": "The block in which the transaction was added",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset_list",
+              "description": "List an ERC20 asset",
+              "label": "",
+              "type": "ERC20AssetList",
+              "longType": "ERC20AssetList",
+              "fullType": "vega.ERC20AssetList",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset_delist",
+              "description": "De-list an ERC20 asset",
+              "label": "",
+              "type": "ERC20AssetDelist",
+              "longType": "ERC20AssetDelist",
+              "fullType": "vega.ERC20AssetDelist",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "deposit",
+              "description": "Deposit ERC20 asset",
+              "label": "",
+              "type": "ERC20Deposit",
+              "longType": "ERC20Deposit",
+              "fullType": "vega.ERC20Deposit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdrawal",
+              "description": "Withdraw ERC20 asset",
+              "label": "",
+              "type": "ERC20Withdrawal",
+              "longType": "ERC20Withdrawal",
+              "fullType": "vega.ERC20Withdrawal",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20Withdrawal",
+          "longName": "ERC20Withdrawal",
+          "fullName": "vega.ERC20Withdrawal",
+          "description": "An asset withdrawal for an ERC20 token",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vega_asset_id",
+              "description": "The Vega network internal identifier of the asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "target_ethereum_address",
+              "description": "The target Ethereum wallet address",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "reference_nonce",
+              "description": "The reference nonce used for the transaction",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EthereumAddress",
+          "longName": "EthereumAddress",
+          "fullName": "vega.EthereumAddress",
+          "description": "Used as a wrapper for an Ethereum address (wallet/contract)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "address",
+              "description": "An Ethereum address",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Identifier",
+          "longName": "Identifier",
+          "fullName": "vega.Identifier",
+          "description": "Used as a wrapper type on any possible network address supported by Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ethereum_address",
+              "description": "Ethereum network",
+              "label": "",
+              "type": "EthereumAddress",
+              "longType": "EthereumAddress",
+              "fullType": "vega.EthereumAddress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "identifier",
+              "defaultValue": ""
+            },
+            {
+              "name": "bitcoin_address",
+              "description": "Bitcoin network",
+              "label": "",
+              "type": "BitcoinAddress",
+              "longType": "BitcoinAddress",
+              "fullType": "vega.BitcoinAddress",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "identifier",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RemoveValidator",
+          "longName": "RemoveValidator",
+          "fullName": "vega.RemoveValidator",
+          "description": "A message to notify when a validator is being removed from the Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The identifier of the validator",
+              "label": "",
+              "type": "Identifier",
+              "longType": "Identifier",
+              "fullType": "vega.Identifier",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidatorEvent",
+          "longName": "ValidatorEvent",
+          "fullName": "vega.ValidatorEvent",
+          "description": "An event related to validator management with foreign networks",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "source_id",
+              "description": "The source identifier of the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "add",
+              "description": "Add a new validator",
+              "label": "",
+              "type": "AddValidator",
+              "longType": "AddValidator",
+              "fullType": "vega.AddValidator",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "rm",
+              "description": "Remove an existing validator",
+              "label": "",
+              "type": "RemoveValidator",
+              "longType": "RemoveValidator",
+              "fullType": "vega.RemoveValidator",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "commands/v1/validator_commands.proto",
+      "description": "",
+      "package": "vega.commands.v1",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "NodeSignatureKind",
+          "longName": "NodeSignatureKind",
+          "fullName": "vega.commands.v1.NodeSignatureKind",
+          "description": "The kind of the signature created by a node, for example, allow-listing a new asset, withdrawal etc",
+          "values": [
+            {
+              "name": "NODE_SIGNATURE_KIND_UNSPECIFIED",
+              "number": "0",
+              "description": "Represents an unspecified or missing value from the input"
+            },
+            {
+              "name": "NODE_SIGNATURE_KIND_ASSET_NEW",
+              "number": "1",
+              "description": "Represents a signature for a new asset allow-listing"
+            },
+            {
+              "name": "NODE_SIGNATURE_KIND_ASSET_WITHDRAWAL",
+              "number": "2",
+              "description": "Represents a signature for an asset withdrawal"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "ChainEvent",
+          "longName": "ChainEvent",
+          "fullName": "vega.commands.v1.ChainEvent",
+          "description": "An event forwarded to the Vega network to provide information on events happening on other networks",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tx_id",
+              "description": "The identifier of the transaction in which the events happened, usually a hash",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "nonce",
+              "description": "Arbitrary one-time integer used to prevent replay attacks",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "builtin",
+              "description": "Built-in asset event",
+              "label": "",
+              "type": "BuiltinAssetEvent",
+              "longType": "vega.BuiltinAssetEvent",
+              "fullType": "vega.BuiltinAssetEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "erc20",
+              "description": "Ethereum ERC20 event",
+              "label": "",
+              "type": "ERC20Event",
+              "longType": "vega.ERC20Event",
+              "fullType": "vega.ERC20Event",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "btc",
+              "description": "Bitcoin BTC event",
+              "label": "",
+              "type": "BTCEvent",
+              "longType": "vega.BTCEvent",
+              "fullType": "vega.BTCEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "validator",
+              "description": "Validator event",
+              "label": "",
+              "type": "ValidatorEvent",
+              "longType": "vega.ValidatorEvent",
+              "fullType": "vega.ValidatorEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NodeRegistration",
+          "longName": "NodeRegistration",
+          "fullName": "vega.commands.v1.NodeRegistration",
+          "description": "Used to Register a node as a validator during network start-up",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_key",
+              "description": "Public key, required field",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "chain_pub_key",
+              "description": "Public key for the blockchain, required field",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "NodeSignature",
+          "longName": "NodeSignature",
+          "fullName": "vega.commands.v1.NodeSignature",
+          "description": "Represents a signature from a validator, to be used by a foreign chain in order to recognise a decision taken by the Vega network",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The identifier of the resource being signed",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sig",
+              "description": "The signature",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "kind",
+              "description": "The kind of resource being signed",
+              "label": "",
+              "type": "NodeSignatureKind",
+              "longType": "NodeSignatureKind",
+              "fullType": "vega.commands.v1.NodeSignatureKind",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NodeVote",
+          "longName": "NodeVote",
+          "fullName": "vega.commands.v1.NodeVote",
+          "description": "Used when a node votes for validating a given resource exists or is valid,\nfor example, an ERC20 deposit is valid and exists on ethereum",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_key",
+              "description": "Public key, required field",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reference",
+              "description": "Reference, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "events/v1/events.proto",
+      "description": "",
+      "package": "vega.events.v1",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "BusEventType",
+          "longName": "BusEventType",
+          "fullName": "vega.events.v1.BusEventType",
+          "description": "An (event) bus event type is used to specify a type of event\nIt has 2 styles of event:\nSingle values (e.g. BUS_EVENT_TYPE_ORDER) where they represent one data item\nGroup values (e.g. BUS_EVENT_TYPE_AUCTION) where they represent a group of data items",
+          "values": [
+            {
+              "name": "BUS_EVENT_TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": "Default value, always invalid"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ALL",
+              "number": "1",
+              "description": "Events of ALL event types, used when filtering stream from event bus"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_TIME_UPDATE",
+              "number": "2",
+              "description": "Event for blockchain time updates"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_TRANSFER_RESPONSES",
+              "number": "3",
+              "description": "Event for when a transfer happens internally, contains the transfer information"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_POSITION_RESOLUTION",
+              "number": "4",
+              "description": "Event indicating position resolution has occurred"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ORDER",
+              "number": "5",
+              "description": "Event for order updates, both new and existing orders"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ACCOUNT",
+              "number": "6",
+              "description": "Event for account updates"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_PARTY",
+              "number": "7",
+              "description": "Event for party updates"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_TRADE",
+              "number": "8",
+              "description": "Event indicating a new trade has occurred"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARGIN_LEVELS",
+              "number": "9",
+              "description": "Event indicating margin levels have changed for a party"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_PROPOSAL",
+              "number": "10",
+              "description": "Event for proposal updates (for governance)"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_VOTE",
+              "number": "11",
+              "description": "Event indicating a new vote has occurred (for governance)"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARKET_DATA",
+              "number": "12",
+              "description": "Event for market data updates"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_NODE_SIGNATURE",
+              "number": "13",
+              "description": "Event for a new signature for a Vega node"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_LOSS_SOCIALIZATION",
+              "number": "14",
+              "description": "Event indicating loss socialisation occurred for a party"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_SETTLE_POSITION",
+              "number": "15",
+              "description": "Event for when a position is being settled"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_SETTLE_DISTRESSED",
+              "number": "16",
+              "description": "Event for when a position is distressed"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARKET_CREATED",
+              "number": "17",
+              "description": "Event indicating a new market was created"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ASSET",
+              "number": "18",
+              "description": "Event for when an asset is added to Vega"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARKET_TICK",
+              "number": "19",
+              "description": "Event indicating a market tick event"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_WITHDRAWAL",
+              "number": "20",
+              "description": "Event for when a withdrawal occurs"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_DEPOSIT",
+              "number": "21",
+              "description": "Event for when a deposit occurs"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_AUCTION",
+              "number": "22",
+              "description": "Event indicating a change in auction state, for example starting or ending an auction"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_RISK_FACTOR",
+              "number": "23",
+              "description": "Event indicating a risk factor has been updated"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_NETWORK_PARAMETER",
+              "number": "24",
+              "description": "Event indicating a network parameter has been added or updated"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_LIQUIDITY_PROVISION",
+              "number": "25",
+              "description": "Event indicating a liquidity provision has been created or updated"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARKET_UPDATED",
+              "number": "26",
+              "description": "Event indicating a new market was created"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ORACLE_SPEC",
+              "number": "27",
+              "description": "Event indicating an oracle spec has been created or updated"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_ORACLE_DATA",
+              "number": "28",
+              "description": "Event indicating that an oracle data has been broadcast"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_MARKET",
+              "number": "101",
+              "description": "Event indicating a market related event, for example when a market opens"
+            },
+            {
+              "name": "BUS_EVENT_TYPE_TX_ERROR",
+              "number": "201",
+              "description": "Event used to report failed transactions back to a user, this is excluded from the ALL type"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "AuctionEvent",
+          "longName": "AuctionEvent",
+          "fullName": "vega.events.v1.AuctionEvent",
+          "description": "An auction event indicating a change in auction state, for example starting or ending an auction",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "opening_auction",
+              "description": "True if the event indicates an auction opening and False otherwise",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "leave",
+              "description": "True if the event indicates leaving auction mode and False otherwise",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "start",
+              "description": "Timestamp containing the start time for an auction",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "end",
+              "description": "Timestamp containing the end time for an auction",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trigger",
+              "description": "the reason this market is/was in auction",
+              "label": "",
+              "type": "AuctionTrigger",
+              "longType": "vega.AuctionTrigger",
+              "fullType": "vega.AuctionTrigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "extension_trigger",
+              "description": "If an auction was ongoing, but was extended for whatever reason, this field will\nbe set to the trigger type indicating which component extended the auction",
+              "label": "",
+              "type": "AuctionTrigger",
+              "longType": "vega.AuctionTrigger",
+              "fullType": "vega.AuctionTrigger",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BusEvent",
+          "longName": "BusEvent",
+          "fullName": "vega.events.v1.BusEvent",
+          "description": "A bus event is a container for event bus events emitted by Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "A unique event identifier for the message",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "block",
+              "description": "The batch (or block) of transactions that the events relate to",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "The type of bus event (one of the list below)",
+              "label": "",
+              "type": "BusEventType",
+              "longType": "BusEventType",
+              "fullType": "vega.events.v1.BusEventType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time_update",
+              "description": "Time update events - See [TimeUpdate](#vega.TimeUpdate)",
+              "label": "",
+              "type": "TimeUpdate",
+              "longType": "TimeUpdate",
+              "fullType": "vega.events.v1.TimeUpdate",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "transfer_responses",
+              "description": "Transfer responses update events - See [TransferResponses](#vega.TransferResponses)",
+              "label": "",
+              "type": "TransferResponses",
+              "longType": "TransferResponses",
+              "fullType": "vega.events.v1.TransferResponses",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "position_resolution",
+              "description": "Position resolution events - See [PositionResolution](#vega.PositionResolution)",
+              "label": "",
+              "type": "PositionResolution",
+              "longType": "PositionResolution",
+              "fullType": "vega.events.v1.PositionResolution",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "order",
+              "description": "Order events",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "account",
+              "description": "Account events",
+              "label": "",
+              "type": "Account",
+              "longType": "vega.Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "party",
+              "description": "Party events",
+              "label": "",
+              "type": "Party",
+              "longType": "vega.Party",
+              "fullType": "vega.Party",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "trade",
+              "description": "Trade events",
+              "label": "",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "margin_levels",
+              "description": "Margin level update events",
+              "label": "",
+              "type": "MarginLevels",
+              "longType": "vega.MarginLevels",
+              "fullType": "vega.MarginLevels",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "proposal",
+              "description": "Proposal events (for governance)",
+              "label": "",
+              "type": "Proposal",
+              "longType": "vega.Proposal",
+              "fullType": "vega.Proposal",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "vote",
+              "description": "Vote events (for governance)",
+              "label": "",
+              "type": "Vote",
+              "longType": "vega.Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_data",
+              "description": "Market data events",
+              "label": "",
+              "type": "MarketData",
+              "longType": "vega.MarketData",
+              "fullType": "vega.MarketData",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "node_signature",
+              "description": "Node signature events",
+              "label": "",
+              "type": "NodeSignature",
+              "longType": "vega.commands.v1.NodeSignature",
+              "fullType": "vega.commands.v1.NodeSignature",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "loss_socialization",
+              "description": "Loss socialization events - See [LossSocialization](#vega.LossSocialization)",
+              "label": "",
+              "type": "LossSocialization",
+              "longType": "LossSocialization",
+              "fullType": "vega.events.v1.LossSocialization",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "settle_position",
+              "description": "Position settlement events - See [SettlePosition](#vega.SettlePosition)",
+              "label": "",
+              "type": "SettlePosition",
+              "longType": "SettlePosition",
+              "fullType": "vega.events.v1.SettlePosition",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "settle_distressed",
+              "description": "Position distressed events - See [SettleDistressed](#vega.SettleDistressed)",
+              "label": "",
+              "type": "SettleDistressed",
+              "longType": "SettleDistressed",
+              "fullType": "vega.events.v1.SettleDistressed",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_created",
+              "description": "Market created events",
+              "label": "",
+              "type": "Market",
+              "longType": "vega.Market",
+              "fullType": "vega.Market",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset events",
+              "label": "",
+              "type": "Asset",
+              "longType": "vega.Asset",
+              "fullType": "vega.Asset",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_tick",
+              "description": "Market tick events - See [MarketTick](#vega.MarketTick)",
+              "label": "",
+              "type": "MarketTick",
+              "longType": "MarketTick",
+              "fullType": "vega.events.v1.MarketTick",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdrawal",
+              "description": "Withdrawal events",
+              "label": "",
+              "type": "Withdrawal",
+              "longType": "vega.Withdrawal",
+              "fullType": "vega.Withdrawal",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "deposit",
+              "description": "Deposit events",
+              "label": "",
+              "type": "Deposit",
+              "longType": "vega.Deposit",
+              "fullType": "vega.Deposit",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "auction",
+              "description": "Auction events - See [AuctionEvent](#vega.AuctionEvent)",
+              "label": "",
+              "type": "AuctionEvent",
+              "longType": "AuctionEvent",
+              "fullType": "vega.events.v1.AuctionEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "risk_factor",
+              "description": "Risk factor events",
+              "label": "",
+              "type": "RiskFactor",
+              "longType": "vega.RiskFactor",
+              "fullType": "vega.RiskFactor",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "network_parameter",
+              "description": "Network parameter events",
+              "label": "",
+              "type": "NetworkParameter",
+              "longType": "vega.NetworkParameter",
+              "fullType": "vega.NetworkParameter",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_provision",
+              "description": "LiquidityProvision  events",
+              "label": "",
+              "type": "LiquidityProvision",
+              "longType": "vega.LiquidityProvision",
+              "fullType": "vega.LiquidityProvision",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_updated",
+              "description": "Market created events",
+              "label": "",
+              "type": "Market",
+              "longType": "vega.Market",
+              "fullType": "vega.Market",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "oracle_spec",
+              "description": "OracleSpec events",
+              "label": "",
+              "type": "OracleSpec",
+              "longType": "oracles.v1.OracleSpec",
+              "fullType": "oracles.v1.OracleSpec",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "oracle_data",
+              "description": "OracleData events",
+              "label": "",
+              "type": "OracleData",
+              "longType": "oracles.v1.OracleData",
+              "fullType": "oracles.v1.OracleData",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "market",
+              "description": "Market tick events - See [MarketEvent](#vega.MarketEvent)",
+              "label": "",
+              "type": "MarketEvent",
+              "longType": "MarketEvent",
+              "fullType": "vega.events.v1.MarketEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            },
+            {
+              "name": "tx_err_event",
+              "description": "Transaction error events, not included in the ALL event type",
+              "label": "",
+              "type": "TxErrorEvent",
+              "longType": "TxErrorEvent",
+              "fullType": "vega.events.v1.TxErrorEvent",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "event",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LossSocialization",
+          "longName": "LossSocialization",
+          "fullName": "vega.events.v1.LossSocialization",
+          "description": "A loss socialization event contains details on the amount of wins unable to be distributed",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier (public key) for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "Amount distributed",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketEvent",
+          "longName": "MarketEvent",
+          "fullName": "vega.events.v1.MarketEvent",
+          "description": "MarketEvent - the common denominator for all market events\ninterface has a method to return a string for logging",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "payload",
+              "description": "Payload is a unique information string",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketTick",
+          "longName": "MarketTick",
+          "fullName": "vega.events.v1.MarketTick",
+          "description": "A market ticket event contains the time value for when a particular market was last processed on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time",
+              "description": "Timestamp containing latest update from Vega blockchain aka Vega-time",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionResolution",
+          "longName": "PositionResolution",
+          "fullName": "vega.events.v1.PositionResolution",
+          "description": "A position resolution event contains information on distressed trades",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "distressed",
+              "description": "Number of distressed traders",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "closed",
+              "description": "Number of close outs",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "mark_price",
+              "description": "Mark price, as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SettleDistressed",
+          "longName": "SettleDistressed",
+          "fullName": "vega.events.v1.SettleDistressed",
+          "description": "A settle distressed event contains information on distressed trading parties who are closed out",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier (public key) for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "margin",
+              "description": "Margin value as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SettlePosition",
+          "longName": "SettlePosition",
+          "fullName": "vega.events.v1.SettlePosition",
+          "description": "A settle position event contains position settlement information for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier (public key) for the event",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price of settlement as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "trade_settlements",
+              "description": "A collection of 1 or more trade settlements",
+              "label": "repeated",
+              "type": "TradeSettlement",
+              "longType": "TradeSettlement",
+              "fullType": "vega.events.v1.TradeSettlement",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TimeUpdate",
+          "longName": "TimeUpdate",
+          "fullName": "vega.events.v1.TimeUpdate",
+          "description": "A time update event contains the latest time update from Vega blockchain",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "timestamp",
+              "description": "Timestamp containing latest update from Vega blockchain aka Vega-time",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradeSettlement",
+          "longName": "TradeSettlement",
+          "fullName": "vega.events.v1.TradeSettlement",
+          "description": "A trade settlement is part of the settle position event",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "size",
+              "description": "Size of trade settlement",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "price",
+              "description": "Price of settlement as an integer, for example `123456` is a correctly\nformatted price of `1.23456` assuming market configured to 5 decimal places",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransferResponses",
+          "longName": "TransferResponses",
+          "fullName": "vega.events.v1.TransferResponses",
+          "description": "A transfer responses event contains a collection of transfer information",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "responses",
+              "description": "One or more entries containing internal transfer information",
+              "label": "repeated",
+              "type": "TransferResponse",
+              "longType": "vega.TransferResponse",
+              "fullType": "vega.TransferResponse",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TxErrorEvent",
+          "longName": "TxErrorEvent",
+          "fullName": "vega.events.v1.TxErrorEvent",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Unique party identifier for the related party",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "err_msg",
+              "description": "An error message describing what went wrong",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "order_submission",
+              "description": "",
+              "label": "",
+              "type": "OrderSubmission",
+              "longType": "vega.commands.v1.OrderSubmission",
+              "fullType": "vega.commands.v1.OrderSubmission",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "order_amendment",
+              "description": "",
+              "label": "",
+              "type": "OrderAmendment",
+              "longType": "vega.commands.v1.OrderAmendment",
+              "fullType": "vega.commands.v1.OrderAmendment",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "order_cancellation",
+              "description": "",
+              "label": "",
+              "type": "OrderCancellation",
+              "longType": "vega.commands.v1.OrderCancellation",
+              "fullType": "vega.commands.v1.OrderCancellation",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "proposal",
+              "description": "",
+              "label": "",
+              "type": "ProposalSubmission",
+              "longType": "vega.commands.v1.ProposalSubmission",
+              "fullType": "vega.commands.v1.ProposalSubmission",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "vote_submission",
+              "description": "",
+              "label": "",
+              "type": "VoteSubmission",
+              "longType": "vega.commands.v1.VoteSubmission",
+              "fullType": "vega.commands.v1.VoteSubmission",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "liquidity_provision_submission",
+              "description": "",
+              "label": "",
+              "type": "LiquidityProvisionSubmission",
+              "longType": "vega.commands.v1.LiquidityProvisionSubmission",
+              "fullType": "vega.commands.v1.LiquidityProvisionSubmission",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            },
+            {
+              "name": "withdraw_submission",
+              "description": "",
+              "label": "",
+              "type": "WithdrawSubmission",
+              "longType": "vega.commands.v1.WithdrawSubmission",
+              "fullType": "vega.commands.v1.WithdrawSubmission",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "transaction",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "api/trading.proto",
+      "description": "",
+      "package": "api.v1",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": true,
+      "enums": [
+        {
+          "name": "Type",
+          "longName": "SubmitTransactionRequest.Type",
+          "fullName": "api.v1.SubmitTransactionRequest.Type",
+          "description": "Blockchain transaction type",
+          "values": [
+            {
+              "name": "TYPE_UNSPECIFIED",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "TYPE_ASYNC",
+              "number": "1",
+              "description": "The transaction will be submitted without waiting for response"
+            },
+            {
+              "name": "TYPE_SYNC",
+              "number": "2",
+              "description": "The transaction will be submitted, and blocking until the\ntendermint mempool return a response"
+            },
+            {
+              "name": "TYPE_COMMIT",
+              "number": "3",
+              "description": "The transaction will submitted, and blocking until the tendermint\nnetwork will have committed it into a block"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "AccountsSubscribeRequest",
+          "longName": "AccountsSubscribeRequest",
+          "fullName": "api.v1.AccountsSubscribeRequest",
+          "description": "Request to subscribe to a stream of (Accounts)[#vega.Account]",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Account type to subscribe to, required field",
+              "label": "",
+              "type": "AccountType",
+              "longType": "vega.AccountType",
+              "fullType": "vega.AccountType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AccountsSubscribeResponse",
+          "longName": "AccountsSubscribeResponse",
+          "fullName": "api.v1.AccountsSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "account",
+              "description": "",
+              "label": "",
+              "type": "Account",
+              "longType": "vega.Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AssetByIDRequest",
+          "longName": "AssetByIDRequest",
+          "fullName": "api.v1.AssetByIDRequest",
+          "description": "Request for an asset given an asset identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Asset identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "AssetByIDResponse",
+          "longName": "AssetByIDResponse",
+          "fullName": "api.v1.AssetByIDResponse",
+          "description": "Response for an asset given an asset identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "asset",
+              "description": "An asset record, if found",
+              "label": "",
+              "type": "Asset",
+              "longType": "vega.Asset",
+              "fullType": "vega.Asset",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "AssetsRequest",
+          "longName": "AssetsRequest",
+          "fullName": "api.v1.AssetsRequest",
+          "description": "Request for a list of all assets enabled on Vega",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "AssetsResponse",
+          "longName": "AssetsResponse",
+          "fullName": "api.v1.AssetsResponse",
+          "description": "Response for a list of all assets enabled on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "assets",
+              "description": "A list of 0 or more assets",
+              "label": "repeated",
+              "type": "Asset",
+              "longType": "vega.Asset",
+              "fullType": "vega.Asset",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CandlesRequest",
+          "longName": "CandlesRequest",
+          "fullName": "api.v1.CandlesRequest",
+          "description": "Request for a list of candles for a market at an interval",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "since_timestamp",
+              "description": "Timestamp to retrieve candles since, in nanoseconds since the epoch,\nrequired field - See [`VegaTimeResponse`](#api.VegaTimeResponse).`timestamp`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "int_gt",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            {
+              "name": "interval",
+              "description": "Time interval for the candles, required field",
+              "label": "",
+              "type": "Interval",
+              "longType": "vega.Interval",
+              "fullType": "vega.Interval",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CandlesResponse",
+          "longName": "CandlesResponse",
+          "fullName": "api.v1.CandlesResponse",
+          "description": "Response for a list of candles for a market at an interval",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "candles",
+              "description": "A list of 0 or more candles",
+              "label": "repeated",
+              "type": "Candle",
+              "longType": "vega.Candle",
+              "fullType": "vega.Candle",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CandlesSubscribeRequest",
+          "longName": "CandlesSubscribeRequest",
+          "fullName": "api.v1.CandlesSubscribeRequest",
+          "description": "Request to subscribe to a stream of (Candles)[#vega.Candle]",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "interval",
+              "description": "Time interval for the candles, required field.",
+              "label": "",
+              "type": "Interval",
+              "longType": "vega.Interval",
+              "fullType": "vega.Interval",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CandlesSubscribeResponse",
+          "longName": "CandlesSubscribeResponse",
+          "fullName": "api.v1.CandlesSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "candle",
+              "description": "",
+              "label": "",
+              "type": "Candle",
+              "longType": "vega.Candle",
+              "fullType": "vega.Candle",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DepositRequest",
+          "longName": "DepositRequest",
+          "fullName": "api.v1.DepositRequest",
+          "description": "A request to get a specific deposit by identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The identifier of the deposit",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DepositResponse",
+          "longName": "DepositResponse",
+          "fullName": "api.v1.DepositResponse",
+          "description": "A response for a deposit",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "deposit",
+              "description": "The deposit matching the identifier from the request",
+              "label": "",
+              "type": "Deposit",
+              "longType": "vega.Deposit",
+              "fullType": "vega.Deposit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "DepositsRequest",
+          "longName": "DepositsRequest",
+          "fullName": "api.v1.DepositsRequest",
+          "description": "A request to get a list of deposit from a given party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "The party to get the deposits for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DepositsResponse",
+          "longName": "DepositsResponse",
+          "fullName": "api.v1.DepositsResponse",
+          "description": "The response for a list of deposits",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "deposits",
+              "description": "The list of deposits for the specified party",
+              "label": "repeated",
+              "type": "Deposit",
+              "longType": "vega.Deposit",
+              "fullType": "vega.Deposit",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ERC20WithdrawalApprovalRequest",
+          "longName": "ERC20WithdrawalApprovalRequest",
+          "fullName": "api.v1.ERC20WithdrawalApprovalRequest",
+          "description": "The request to get all information required to bundle the call to finalise the withdrawal on the erc20 bridge",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "withdrawal_id",
+              "description": "The identifier of the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ERC20WithdrawalApprovalResponse",
+          "longName": "ERC20WithdrawalApprovalResponse",
+          "fullName": "api.v1.ERC20WithdrawalApprovalResponse",
+          "description": "The response with all information required to bundle the call to finalise the withdrawal on the erc20 bridge\nfunction withdraw_asset(address asset_source, uint256 asset_id, uint256 amount, uint256 expiry, uint256 nonce, bytes memory signatures)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "asset_source",
+              "description": "The address of asset on ethereum",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "amount",
+              "description": "The amount to be withdrawn",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "expiry",
+              "description": "The expiry / until what time the request is valid",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "nonce",
+              "description": "The nonce, which is actually the internal reference for the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "signatures",
+              "description": "The signatures bundle as hex encoded data, forward by 0x\ne.g: 0x + sig1 + sig2 + ... + sixN",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EstimateFeeRequest",
+          "longName": "EstimateFeeRequest",
+          "fullName": "api.v1.EstimateFeeRequest",
+          "description": "Request to fetch the estimated fee if an order were to trade immediately",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "Order to estimate fees for\nthe following fields in the order are required:\nMarketID (used to specify the fee factors)\nPrice (the price at which the order could trade)\nSize (the size at which the order could eventually trade)",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EstimateFeeResponse",
+          "longName": "EstimateFeeResponse",
+          "fullName": "api.v1.EstimateFeeResponse",
+          "description": "Response to a EstimateFeeRequest, containing the estimated fees for a given order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "fee",
+              "description": "Summary of the estimated fees for this order if it were to trade now",
+              "label": "",
+              "type": "Fee",
+              "longType": "vega.Fee",
+              "fullType": "vega.Fee",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EstimateMarginRequest",
+          "longName": "EstimateMarginRequest",
+          "fullName": "api.v1.EstimateMarginRequest",
+          "description": "Request to fetch the estimated MarginLevels if an order were to trade immediately",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "Order to estimate fees for",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EstimateMarginResponse",
+          "longName": "EstimateMarginResponse",
+          "fullName": "api.v1.EstimateMarginResponse",
+          "description": "Response to a EstimateMarginRequest, containing the estimated marginLevels for a given order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "margin_levels",
+              "description": "Summary of the estimated margins for this order if it were to trade now",
+              "label": "",
+              "type": "MarginLevels",
+              "longType": "vega.MarginLevels",
+              "fullType": "vega.MarginLevels",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FeeInfrastructureAccountsRequest",
+          "longName": "FeeInfrastructureAccountsRequest",
+          "fullName": "api.v1.FeeInfrastructureAccountsRequest",
+          "description": "Request for a list of infrastructure fee accounts",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "asset",
+              "description": "Asset identifier, required field\n- Set to an empty string to return all accounts\n- Set to an asset ID to return a single infrastructure fee account for a given asset",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "FeeInfrastructureAccountsResponse",
+          "longName": "FeeInfrastructureAccountsResponse",
+          "fullName": "api.v1.FeeInfrastructureAccountsResponse",
+          "description": "Response for a list of infrastructure fee accounts",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "accounts",
+              "description": "A list of 0 or more infrastructure fee accounts",
+              "label": "repeated",
+              "type": "Account",
+              "longType": "vega.Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNetworkParametersProposalsRequest",
+          "longName": "GetNetworkParametersProposalsRequest",
+          "fullName": "api.v1.GetNetworkParametersProposalsRequest",
+          "description": "Request for a list of network parameter proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "select_in_state",
+              "description": "Optional proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNetworkParametersProposalsResponse",
+          "longName": "GetNetworkParametersProposalsResponse",
+          "fullName": "api.v1.GetNetworkParametersProposalsResponse",
+          "description": "Response for a list of network parameter proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNewAssetProposalsRequest",
+          "longName": "GetNewAssetProposalsRequest",
+          "fullName": "api.v1.GetNewAssetProposalsRequest",
+          "description": "Request for a list of new asset proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "select_in_state",
+              "description": "Optional proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNewAssetProposalsResponse",
+          "longName": "GetNewAssetProposalsResponse",
+          "fullName": "api.v1.GetNewAssetProposalsResponse",
+          "description": "Response for a list of new asset proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNewMarketProposalsRequest",
+          "longName": "GetNewMarketProposalsRequest",
+          "fullName": "api.v1.GetNewMarketProposalsRequest",
+          "description": "Request for a list of new market proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "select_in_state",
+              "description": "Optional proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNewMarketProposalsResponse",
+          "longName": "GetNewMarketProposalsResponse",
+          "fullName": "api.v1.GetNewMarketProposalsResponse",
+          "description": "Response for a list of new market proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetNodeSignaturesAggregateRequest",
+          "longName": "GetNodeSignaturesAggregateRequest",
+          "fullName": "api.v1.GetNodeSignaturesAggregateRequest",
+          "description": "Request to specify the identifier of the resource we want to retrieve aggregated signatures for",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "Resource identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetNodeSignaturesAggregateResponse",
+          "longName": "GetNodeSignaturesAggregateResponse",
+          "fullName": "api.v1.GetNodeSignaturesAggregateResponse",
+          "description": "Response to specify the identifier of the resource we want to retrieve aggregated signatures for",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "signatures",
+              "description": "A list of 0 or more signatures",
+              "label": "repeated",
+              "type": "NodeSignature",
+              "longType": "vega.commands.v1.NodeSignature",
+              "fullType": "vega.commands.v1.NodeSignature",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalByIDRequest",
+          "longName": "GetProposalByIDRequest",
+          "fullName": "api.v1.GetProposalByIDRequest",
+          "description": "Request for a governance proposal given a proposal identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "proposal_id",
+              "description": "Proposal identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetProposalByIDResponse",
+          "longName": "GetProposalByIDResponse",
+          "fullName": "api.v1.GetProposalByIDResponse",
+          "description": "Response for a governance proposal given a proposal identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "Governance data, if found",
+              "label": "",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalByReferenceRequest",
+          "longName": "GetProposalByReferenceRequest",
+          "fullName": "api.v1.GetProposalByReferenceRequest",
+          "description": "Request for a governance proposal given a proposal reference",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "reference",
+              "description": "Proposal reference. Required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetProposalByReferenceResponse",
+          "longName": "GetProposalByReferenceResponse",
+          "fullName": "api.v1.GetProposalByReferenceResponse",
+          "description": "Response for a governance proposal given a proposal reference",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "Governance data, if found",
+              "label": "",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalsByPartyRequest",
+          "longName": "GetProposalsByPartyRequest",
+          "fullName": "api.v1.GetProposalsByPartyRequest",
+          "description": "Request for a list of proposals for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "select_in_state",
+              "description": "Optional proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalsByPartyResponse",
+          "longName": "GetProposalsByPartyResponse",
+          "fullName": "api.v1.GetProposalsByPartyResponse",
+          "description": "Response for a list of proposals for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalsRequest",
+          "longName": "GetProposalsRequest",
+          "fullName": "api.v1.GetProposalsRequest",
+          "description": "Request for a list of proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "select_in_state",
+              "description": "Optional proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetProposalsResponse",
+          "longName": "GetProposalsResponse",
+          "fullName": "api.v1.GetProposalsResponse",
+          "description": "Response for a list of proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetUpdateMarketProposalsRequest",
+          "longName": "GetUpdateMarketProposalsRequest",
+          "fullName": "api.v1.GetUpdateMarketProposalsRequest",
+          "description": "Request for a list of update market proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "select_in_state",
+              "description": "Proposal state",
+              "label": "",
+              "type": "OptionalProposalState",
+              "longType": "OptionalProposalState",
+              "fullType": "api.v1.OptionalProposalState",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetUpdateMarketProposalsResponse",
+          "longName": "GetUpdateMarketProposalsResponse",
+          "fullName": "api.v1.GetUpdateMarketProposalsResponse",
+          "description": "Response for a list of update market proposals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "A list of 0 or more governance data",
+              "label": "repeated",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetVegaTimeRequest",
+          "longName": "GetVegaTimeRequest",
+          "fullName": "api.v1.GetVegaTimeRequest",
+          "description": "Request for the current time of the vega network",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "GetVegaTimeResponse",
+          "longName": "GetVegaTimeResponse",
+          "fullName": "api.v1.GetVegaTimeResponse",
+          "description": "Response for the current consensus coordinated time on the Vega network, referred to as \"VegaTime\"",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "timestamp",
+              "description": "Timestamp representation of current VegaTime as represented in\nNanoseconds since the epoch, for example `1580473859111222333` corresponds to `2020-01-31T12:30:59.111222333Z`",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "GetVotesByPartyRequest",
+          "longName": "GetVotesByPartyRequest",
+          "fullName": "api.v1.GetVotesByPartyRequest",
+          "description": "Request for a list of votes for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GetVotesByPartyResponse",
+          "longName": "GetVotesByPartyResponse",
+          "fullName": "api.v1.GetVotesByPartyResponse",
+          "description": "Response for a list of votes for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "votes",
+              "description": "A list of 0 or more votes",
+              "label": "repeated",
+              "type": "Vote",
+              "longType": "vega.Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LastTradeRequest",
+          "longName": "LastTradeRequest",
+          "fullName": "api.v1.LastTradeRequest",
+          "description": "Request for the latest trade that occurred on Vega for a given market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "LastTradeResponse",
+          "longName": "LastTradeResponse",
+          "fullName": "api.v1.LastTradeResponse",
+          "description": "Response for the latest trade that occurred on Vega for a given market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trade",
+              "description": "A trade, if found",
+              "label": "",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityProvisionsRequest",
+          "longName": "LiquidityProvisionsRequest",
+          "fullName": "api.v1.LiquidityProvisionsRequest",
+          "description": "A message requesting for the list of liquidity provision orders for markets\nOne of the two filters is required (or both)",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market",
+              "description": "The target market for the liquidity provision orders",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party",
+              "description": "The party which submitted the liquidity provision orders",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LiquidityProvisionsResponse",
+          "longName": "LiquidityProvisionsResponse",
+          "fullName": "api.v1.LiquidityProvisionsResponse",
+          "description": "A response containing all of the Vega liquidity provision orders",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "liquidity_provisions",
+              "description": "",
+              "label": "repeated",
+              "type": "LiquidityProvision",
+              "longType": "vega.LiquidityProvision",
+              "fullType": "vega.LiquidityProvision",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginLevelsRequest",
+          "longName": "MarginLevelsRequest",
+          "fullName": "api.v1.MarginLevelsRequest",
+          "description": "Request for margin levels for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginLevelsResponse",
+          "longName": "MarginLevelsResponse",
+          "fullName": "api.v1.MarginLevelsResponse",
+          "description": "Response for margin levels for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "margin_levels",
+              "description": "A list of 0 or more margin levels",
+              "label": "repeated",
+              "type": "MarginLevels",
+              "longType": "vega.MarginLevels",
+              "fullType": "vega.MarginLevels",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginLevelsSubscribeRequest",
+          "longName": "MarginLevelsSubscribeRequest",
+          "fullName": "api.v1.MarginLevelsSubscribeRequest",
+          "description": "Request to subscribe to a stream of MarginLevels data matching the given party identifier\nOptionally, the list can be additionally filtered by market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarginLevelsSubscribeResponse",
+          "longName": "MarginLevelsSubscribeResponse",
+          "fullName": "api.v1.MarginLevelsSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "margin_levels",
+              "description": "",
+              "label": "",
+              "type": "MarginLevels",
+              "longType": "vega.MarginLevels",
+              "fullType": "vega.MarginLevels",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketAccountsRequest",
+          "longName": "MarketAccountsRequest",
+          "fullName": "api.v1.MarketAccountsRequest",
+          "description": "Request for a list of accounts for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketAccountsResponse",
+          "longName": "MarketAccountsResponse",
+          "fullName": "api.v1.MarketAccountsResponse",
+          "description": "Response for a list of accounts for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "accounts",
+              "description": "A list of 0 or more accounts",
+              "label": "repeated",
+              "type": "Account",
+              "longType": "vega.Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketByIDRequest",
+          "longName": "MarketByIDRequest",
+          "fullName": "api.v1.MarketByIDRequest",
+          "description": "Request for a market given a market identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "MarketByIDResponse",
+          "longName": "MarketByIDResponse",
+          "fullName": "api.v1.MarketByIDResponse",
+          "description": "Response for a market given a market identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market",
+              "description": "A market, if found",
+              "label": "",
+              "type": "Market",
+              "longType": "vega.Market",
+              "fullType": "vega.Market",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDataByIDRequest",
+          "longName": "MarketDataByIDRequest",
+          "fullName": "api.v1.MarketDataByIDRequest",
+          "description": "Request for market data for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "MarketDataByIDResponse",
+          "longName": "MarketDataByIDResponse",
+          "fullName": "api.v1.MarketDataByIDResponse",
+          "description": "Response for market data for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_data",
+              "description": "Market data, if found",
+              "label": "",
+              "type": "MarketData",
+              "longType": "vega.MarketData",
+              "fullType": "vega.MarketData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthRequest",
+          "longName": "MarketDepthRequest",
+          "fullName": "api.v1.MarketDepthRequest",
+          "description": "Request for the market depth/order book price levels on a market\nOptionally, a maximum depth can be set to limit the number of levels returned",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "max_depth",
+              "description": "Max depth limits the number of levels returned. Default is 0, which returns all levels",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthResponse",
+          "longName": "MarketDepthResponse",
+          "fullName": "api.v1.MarketDepthResponse",
+          "description": "Response for the market depth/order book price levels on a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "buy",
+              "description": "Zero or more price levels for the buy side of the market depth data",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "vega.PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sell",
+              "description": "Zero or more price levels for the sell side of the market depth data",
+              "label": "repeated",
+              "type": "PriceLevel",
+              "longType": "vega.PriceLevel",
+              "fullType": "vega.PriceLevel",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_trade",
+              "description": "Last trade recorded on Vega at the time of retrieving the `MarketDepthResponse`",
+              "label": "",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "sequence_number",
+              "description": "Sequence number incremented after each update",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthSubscribeRequest",
+          "longName": "MarketDepthSubscribeRequest",
+          "fullName": "api.v1.MarketDepthSubscribeRequest",
+          "description": "Request to subscribe to a stream of (MarketDepth)[#vega.MarketDepth] data",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthSubscribeResponse",
+          "longName": "MarketDepthSubscribeResponse",
+          "fullName": "api.v1.MarketDepthSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_depth",
+              "description": "",
+              "label": "",
+              "type": "MarketDepth",
+              "longType": "vega.MarketDepth",
+              "fullType": "vega.MarketDepth",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthUpdatesSubscribeRequest",
+          "longName": "MarketDepthUpdatesSubscribeRequest",
+          "fullName": "api.v1.MarketDepthUpdatesSubscribeRequest",
+          "description": "Request to subscribe to a stream of (MarketDepth Update)[#vega.MarketDepthUpdate] data",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "MarketDepthUpdatesSubscribeResponse",
+          "longName": "MarketDepthUpdatesSubscribeResponse",
+          "fullName": "api.v1.MarketDepthUpdatesSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "update",
+              "description": "",
+              "label": "",
+              "type": "MarketDepthUpdate",
+              "longType": "vega.MarketDepthUpdate",
+              "fullType": "vega.MarketDepthUpdate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketsDataRequest",
+          "longName": "MarketsDataRequest",
+          "fullName": "api.v1.MarketsDataRequest",
+          "description": "Request for market data",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "MarketsDataResponse",
+          "longName": "MarketsDataResponse",
+          "fullName": "api.v1.MarketsDataResponse",
+          "description": "Response for market data",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "markets_data",
+              "description": "A list of 0 or more market data",
+              "label": "repeated",
+              "type": "MarketData",
+              "longType": "vega.MarketData",
+              "fullType": "vega.MarketData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketsDataSubscribeRequest",
+          "longName": "MarketsDataSubscribeRequest",
+          "fullName": "api.v1.MarketsDataSubscribeRequest",
+          "description": "Request to subscribe to a stream of MarketsData\nOptionally, the list can be additionally filtered by market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketsDataSubscribeResponse",
+          "longName": "MarketsDataSubscribeResponse",
+          "fullName": "api.v1.MarketsDataSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_data",
+              "description": "",
+              "label": "",
+              "type": "MarketData",
+              "longType": "vega.MarketData",
+              "fullType": "vega.MarketData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "MarketsRequest",
+          "longName": "MarketsRequest",
+          "fullName": "api.v1.MarketsRequest",
+          "description": "Request for a list of markets on Vega",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "MarketsResponse",
+          "longName": "MarketsResponse",
+          "fullName": "api.v1.MarketsResponse",
+          "description": "Response for a list of markets on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "markets",
+              "description": "A list of 0 or more markets",
+              "label": "repeated",
+              "type": "Market",
+              "longType": "vega.Market",
+              "fullType": "vega.Market",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "NetworkParametersRequest",
+          "longName": "NetworkParametersRequest",
+          "fullName": "api.v1.NetworkParametersRequest",
+          "description": "A message requesting for the list of all network parameters",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "NetworkParametersResponse",
+          "longName": "NetworkParametersResponse",
+          "fullName": "api.v1.NetworkParametersResponse",
+          "description": "A response containing all of the vega network parameters",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "network_parameters",
+              "description": "",
+              "label": "repeated",
+              "type": "NetworkParameter",
+              "longType": "vega.NetworkParameter",
+              "fullType": "vega.NetworkParameter",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObserveEventBusRequest",
+          "longName": "ObserveEventBusRequest",
+          "fullName": "api.v1.ObserveEventBusRequest",
+          "description": "Request to subscribe to a stream of one or more event types from the Vega event bus",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "One or more types of event, required field",
+              "label": "repeated",
+              "type": "BusEventType",
+              "longType": "vega.events.v1.BusEventType",
+              "fullType": "vega.events.v1.BusEventType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier, optional field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier, optional field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "batch_size",
+              "description": "Batch size, optional field -\nIf not specified, any events received will be sent immediately. If the client is not ready\nfor the next data-set, data may be dropped a number of times, and eventually the stream is closed.\nif specified, the first batch will be sent when ready. To receive the next set of events, the client\nmust write an `ObserveEventBatch` message on the stream to flush the buffer.\nIf no message is received in 5 seconds, the stream is closed.\nDefault: 0, send any and all events when they are available.",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObserveEventBusResponse",
+          "longName": "ObserveEventBusResponse",
+          "fullName": "api.v1.ObserveEventBusResponse",
+          "description": "Response to a subscribed stream of events from the Vega event bus",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "events",
+              "description": "One or more events",
+              "label": "repeated",
+              "type": "BusEvent",
+              "longType": "vega.events.v1.BusEvent",
+              "fullType": "vega.events.v1.BusEvent",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObserveGovernanceRequest",
+          "longName": "ObserveGovernanceRequest",
+          "fullName": "api.v1.ObserveGovernanceRequest",
+          "description": "Request to obsever all event related to governance",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "ObserveGovernanceResponse",
+          "longName": "ObserveGovernanceResponse",
+          "fullName": "api.v1.ObserveGovernanceResponse",
+          "description": "All events related to governance",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "",
+              "label": "",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObservePartyProposalsRequest",
+          "longName": "ObservePartyProposalsRequest",
+          "fullName": "api.v1.ObservePartyProposalsRequest",
+          "description": "Request to subscribe to a stream of governance proposals for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ObservePartyProposalsResponse",
+          "longName": "ObservePartyProposalsResponse",
+          "fullName": "api.v1.ObservePartyProposalsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "data",
+              "description": "",
+              "label": "",
+              "type": "GovernanceData",
+              "longType": "vega.GovernanceData",
+              "fullType": "vega.GovernanceData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObservePartyVotesRequest",
+          "longName": "ObservePartyVotesRequest",
+          "fullName": "api.v1.ObservePartyVotesRequest",
+          "description": "Request to subscribe to a stream of governance votes for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ObservePartyVotesResponse",
+          "longName": "ObservePartyVotesResponse",
+          "fullName": "api.v1.ObservePartyVotesResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vote",
+              "description": "",
+              "label": "",
+              "type": "Vote",
+              "longType": "vega.Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ObserveProposalVotesRequest",
+          "longName": "ObserveProposalVotesRequest",
+          "fullName": "api.v1.ObserveProposalVotesRequest",
+          "description": "Request to subscribe to a stream of governance votes for a proposal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "proposal_id",
+              "description": "Proposal identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "ObserveProposalVotesResponse",
+          "longName": "ObserveProposalVotesResponse",
+          "fullName": "api.v1.ObserveProposalVotesResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "vote",
+              "description": "",
+              "label": "",
+              "type": "Vote",
+              "longType": "vega.Vote",
+              "fullType": "vega.Vote",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OptionalProposalState",
+          "longName": "OptionalProposalState",
+          "fullName": "api.v1.OptionalProposalState",
+          "description": "Optional proposal state",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "value",
+              "description": "Proposal state value",
+              "label": "",
+              "type": "State",
+              "longType": "vega.Proposal.State",
+              "fullType": "vega.Proposal.State",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleDataBySpecRequest",
+          "longName": "OracleDataBySpecRequest",
+          "fullName": "api.v1.OracleDataBySpecRequest",
+          "description": "A request to all oracle data broadcast to a given spec",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id to get the oracle spec for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "OracleDataBySpecResponse",
+          "longName": "OracleDataBySpecResponse",
+          "fullName": "api.v1.OracleDataBySpecResponse",
+          "description": "The response for a list of all oracle data broadcast to a given spec",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "oracle_data",
+              "description": "The list of oracle data broadcast to a given spec",
+              "label": "repeated",
+              "type": "OracleData",
+              "longType": "oracles.v1.OracleData",
+              "fullType": "oracles.v1.OracleData",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleSpecRequest",
+          "longName": "OracleSpecRequest",
+          "fullName": "api.v1.OracleSpecRequest",
+          "description": "A request to get a specific oracle spec by identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id to get the oracle spec for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "OracleSpecResponse",
+          "longName": "OracleSpecResponse",
+          "fullName": "api.v1.OracleSpecResponse",
+          "description": "A response for a oracle spec",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "oracle_spec",
+              "description": "The withdrawal matching the identifier from the request",
+              "label": "",
+              "type": "OracleSpec",
+              "longType": "oracles.v1.OracleSpec",
+              "fullType": "oracles.v1.OracleSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OracleSpecsRequest",
+          "longName": "OracleSpecsRequest",
+          "fullName": "api.v1.OracleSpecsRequest",
+          "description": "A request to get a specific oracle spec by identifier",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "OracleSpecsResponse",
+          "longName": "OracleSpecsResponse",
+          "fullName": "api.v1.OracleSpecsResponse",
+          "description": "The response for a list of withdrawals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "oracle_specs",
+              "description": "The list of oracle specs",
+              "label": "repeated",
+              "type": "OracleSpec",
+              "longType": "oracles.v1.OracleSpec",
+              "fullType": "oracles.v1.OracleSpec",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderByIDRequest",
+          "longName": "OrderByIDRequest",
+          "fullName": "api.v1.OrderByIDRequest",
+          "description": "Request for an order with the specified order identifier\nOptionally, return a specific version of the order with the `version` field",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Order identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "version",
+              "description": "Version of the order:\n- Set `version` to 0 for most recent version of the order\n- Set `1` for original version of the order\n- Set `2` for first amendment, `3` for second amendment, etc",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderByIDResponse",
+          "longName": "OrderByIDResponse",
+          "fullName": "api.v1.OrderByIDResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderByMarketAndIDRequest",
+          "longName": "OrderByMarketAndIDRequest",
+          "fullName": "api.v1.OrderByMarketAndIDRequest",
+          "description": "Request for an order on a market given an order identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "order_id",
+              "description": "Order identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "OrderByMarketAndIDResponse",
+          "longName": "OrderByMarketAndIDResponse",
+          "fullName": "api.v1.OrderByMarketAndIDResponse",
+          "description": "Response for an order on a market given an order identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "An order, if found",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderByReferenceRequest",
+          "longName": "OrderByReferenceRequest",
+          "fullName": "api.v1.OrderByReferenceRequest",
+          "description": "Request for an order given an order reference",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "reference",
+              "description": "Unique reference, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "OrderByReferenceResponse",
+          "longName": "OrderByReferenceResponse",
+          "fullName": "api.v1.OrderByReferenceResponse",
+          "description": "Response for an order given an order reference",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order",
+              "description": "An order, if found",
+              "label": "",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderVersionsByIDRequest",
+          "longName": "OrderVersionsByIDRequest",
+          "fullName": "api.v1.OrderVersionsByIDRequest",
+          "description": "Request for a list of all versions of an order given the specified order identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Order identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "pagination",
+              "description": "Pagination controls",
+              "label": "",
+              "type": "Pagination",
+              "longType": "Pagination",
+              "fullType": "api.v1.Pagination",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrderVersionsByIDResponse",
+          "longName": "OrderVersionsByIDResponse",
+          "fullName": "api.v1.OrderVersionsByIDResponse",
+          "description": "Response to a request for a list of all versions of an order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "orders",
+              "description": "A list of 0 or more orders (list will contain the same order but with different versions, if it has been amended)",
+              "label": "repeated",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersByMarketRequest",
+          "longName": "OrdersByMarketRequest",
+          "fullName": "api.v1.OrdersByMarketRequest",
+          "description": "Request for a list of orders for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "pagination",
+              "description": "Optional pagination controls",
+              "label": "",
+              "type": "Pagination",
+              "longType": "Pagination",
+              "fullType": "api.v1.Pagination",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersByMarketResponse",
+          "longName": "OrdersByMarketResponse",
+          "fullName": "api.v1.OrdersByMarketResponse",
+          "description": "Response for a list of orders for a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "orders",
+              "description": "A list of 0 or more orders",
+              "label": "repeated",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersByPartyRequest",
+          "longName": "OrdersByPartyRequest",
+          "fullName": "api.v1.OrdersByPartyRequest",
+          "description": "Request for a list of orders for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "pagination",
+              "description": "Pagination controls",
+              "label": "",
+              "type": "Pagination",
+              "longType": "Pagination",
+              "fullType": "api.v1.Pagination",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersByPartyResponse",
+          "longName": "OrdersByPartyResponse",
+          "fullName": "api.v1.OrdersByPartyResponse",
+          "description": "Response for a list of orders for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "orders",
+              "description": "A list of 0 or more orders",
+              "label": "repeated",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersSubscribeRequest",
+          "longName": "OrdersSubscribeRequest",
+          "fullName": "api.v1.OrdersSubscribeRequest",
+          "description": "Request to subscribe to a stream of (Orders)[#vega.Order]",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "OrdersSubscribeResponse",
+          "longName": "OrdersSubscribeResponse",
+          "fullName": "api.v1.OrdersSubscribeResponse",
+          "description": "A stream of orders",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "orders",
+              "description": "A list of 0 or more orders",
+              "label": "repeated",
+              "type": "Order",
+              "longType": "vega.Order",
+              "fullType": "vega.Order",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Pagination",
+          "longName": "Pagination",
+          "fullName": "api.v1.Pagination",
+          "description": "Pagination controls",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "skip",
+              "description": "Skip the number of records specified, default is 0",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "limit",
+              "description": "Limit the number of returned records to the value specified, default is 50",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "descending",
+              "description": "Descending reverses the order of the records returned,\ndefault is true, if false the results will be returned in ascending order",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PartiesRequest",
+          "longName": "PartiesRequest",
+          "fullName": "api.v1.PartiesRequest",
+          "description": "Request for a list of all parties",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "PartiesResponse",
+          "longName": "PartiesResponse",
+          "fullName": "api.v1.PartiesResponse",
+          "description": "Response to a request for a list of parties",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "parties",
+              "description": "A list of 0 or more parties",
+              "label": "repeated",
+              "type": "Party",
+              "longType": "vega.Party",
+              "fullType": "vega.Party",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PartyAccountsRequest",
+          "longName": "PartyAccountsRequest",
+          "fullName": "api.v1.PartyAccountsRequest",
+          "description": "Request for a list of accounts for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Account type, required field",
+              "label": "",
+              "type": "AccountType",
+              "longType": "vega.AccountType",
+              "fullType": "vega.AccountType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "asset",
+              "description": "Asset identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PartyAccountsResponse",
+          "longName": "PartyAccountsResponse",
+          "fullName": "api.v1.PartyAccountsResponse",
+          "description": "Response for a list of accounts for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "accounts",
+              "description": "A list of 0 or more accounts",
+              "label": "repeated",
+              "type": "Account",
+              "longType": "vega.Account",
+              "fullType": "vega.Account",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PartyByIDRequest",
+          "longName": "PartyByIDRequest",
+          "fullName": "api.v1.PartyByIDRequest",
+          "description": "Request for a party given a party identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PartyByIDResponse",
+          "longName": "PartyByIDResponse",
+          "fullName": "api.v1.PartyByIDResponse",
+          "description": "Response for a party given a party identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party",
+              "description": "A party, if found",
+              "label": "",
+              "type": "Party",
+              "longType": "vega.Party",
+              "fullType": "vega.Party",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionsByPartyRequest",
+          "longName": "PositionsByPartyRequest",
+          "fullName": "api.v1.PositionsByPartyRequest",
+          "description": "Request for a list of positions for a party\nOptionally, if a market identifier is set, the results will be filtered for that market only",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionsByPartyResponse",
+          "longName": "PositionsByPartyResponse",
+          "fullName": "api.v1.PositionsByPartyResponse",
+          "description": "Response for a list of positions for a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "positions",
+              "description": "A list of 0 or more positions",
+              "label": "repeated",
+              "type": "Position",
+              "longType": "vega.Position",
+              "fullType": "vega.Position",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionsSubscribeRequest",
+          "longName": "PositionsSubscribeRequest",
+          "fullName": "api.v1.PositionsSubscribeRequest",
+          "description": "Request to subscribe to a stream of (Positions)[#vega.Position]",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier, optional field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier, optional field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PositionsSubscribeResponse",
+          "longName": "PositionsSubscribeResponse",
+          "fullName": "api.v1.PositionsSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "position",
+              "description": "",
+              "label": "",
+              "type": "Position",
+              "longType": "vega.Position",
+              "fullType": "vega.Position",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareAmendOrderRequest",
+          "longName": "PrepareAmendOrderRequest",
+          "fullName": "api.v1.PrepareAmendOrderRequest",
+          "description": "Request to amend an existing order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "amendment",
+              "description": "An order amendment",
+              "label": "",
+              "type": "OrderAmendment",
+              "longType": "vega.commands.v1.OrderAmendment",
+              "fullType": "vega.commands.v1.OrderAmendment",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareAmendOrderResponse",
+          "longName": "PrepareAmendOrderResponse",
+          "fullName": "api.v1.PrepareAmendOrderResponse",
+          "description": "Response for preparing an order amendment",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "Blob is an encoded representation of the order amendment ready to sign using the Vega Wallet and then submit as a transaction.",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareCancelOrderRequest",
+          "longName": "PrepareCancelOrderRequest",
+          "fullName": "api.v1.PrepareCancelOrderRequest",
+          "description": "Request to cancel an existing order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "cancellation",
+              "description": "An order cancellation",
+              "label": "",
+              "type": "OrderCancellation",
+              "longType": "vega.commands.v1.OrderCancellation",
+              "fullType": "vega.commands.v1.OrderCancellation",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareCancelOrderResponse",
+          "longName": "PrepareCancelOrderResponse",
+          "fullName": "api.v1.PrepareCancelOrderResponse",
+          "description": "Response for preparing an order cancellation",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "Blob is an encoded representation of the order cancellation ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareLiquidityProvisionRequest",
+          "longName": "PrepareLiquidityProvisionRequest",
+          "fullName": "api.v1.PrepareLiquidityProvisionRequest",
+          "description": "Request to prepare liquiditity provision",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "submission",
+              "description": "Submission, required field",
+              "label": "",
+              "type": "LiquidityProvisionSubmission",
+              "longType": "vega.commands.v1.LiquidityProvisionSubmission",
+              "fullType": "vega.commands.v1.LiquidityProvisionSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PrepareLiquidityProvisionResponse",
+          "longName": "PrepareLiquidityProvisionResponse",
+          "fullName": "api.v1.PrepareLiquidityProvisionResponse",
+          "description": "Response to a liquidity provision request",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "A blob is an encoded representation of the liquidity provision message ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareProposalSubmissionRequest",
+          "longName": "PrepareProposalSubmissionRequest",
+          "fullName": "api.v1.PrepareProposalSubmissionRequest",
+          "description": "Request to prepare a governance proposal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "submission",
+              "description": "",
+              "label": "",
+              "type": "ProposalSubmission",
+              "longType": "vega.commands.v1.ProposalSubmission",
+              "fullType": "vega.commands.v1.ProposalSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareProposalSubmissionResponse",
+          "longName": "PrepareProposalSubmissionResponse",
+          "fullName": "api.v1.PrepareProposalSubmissionResponse",
+          "description": "Response to prepare a governance proposal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "A blob is an encoded representation of the proposal ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "submission",
+              "description": "A copy of the prepared proposal",
+              "label": "",
+              "type": "ProposalSubmission",
+              "longType": "vega.commands.v1.ProposalSubmission",
+              "fullType": "vega.commands.v1.ProposalSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareSubmitOrderRequest",
+          "longName": "PrepareSubmitOrderRequest",
+          "fullName": "api.v1.PrepareSubmitOrderRequest",
+          "description": "Request to submit a new order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "submission",
+              "description": "An order submission",
+              "label": "",
+              "type": "OrderSubmission",
+              "longType": "vega.commands.v1.OrderSubmission",
+              "fullType": "vega.commands.v1.OrderSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareSubmitOrderResponse",
+          "longName": "PrepareSubmitOrderResponse",
+          "fullName": "api.v1.PrepareSubmitOrderResponse",
+          "description": "Response for preparing an order submission",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "Blob is an encoded representation of the order submission ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "submit_id",
+              "description": "Submission identifier (order reference)",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareVoteSubmissionRequest",
+          "longName": "PrepareVoteSubmissionRequest",
+          "fullName": "api.v1.PrepareVoteSubmissionRequest",
+          "description": "Request to prepare a governance vote",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "submission",
+              "description": "Vote, required field",
+              "label": "",
+              "type": "VoteSubmission",
+              "longType": "vega.commands.v1.VoteSubmission",
+              "fullType": "vega.commands.v1.VoteSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "msg_exists",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PrepareVoteSubmissionResponse",
+          "longName": "PrepareVoteSubmissionResponse",
+          "fullName": "api.v1.PrepareVoteSubmissionResponse",
+          "description": "Response to prepare a governance vote",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "A blob is an encoded representation of the vote ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "submission",
+              "description": "A copy of the prepared vote",
+              "label": "",
+              "type": "VoteSubmission",
+              "longType": "vega.commands.v1.VoteSubmission",
+              "fullType": "vega.commands.v1.VoteSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareWithdrawRequest",
+          "longName": "PrepareWithdrawRequest",
+          "fullName": "api.v1.PrepareWithdrawRequest",
+          "description": "Request for preparing a withdrawal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "withdraw",
+              "description": "An asset withdrawal",
+              "label": "",
+              "type": "WithdrawSubmission",
+              "longType": "vega.commands.v1.WithdrawSubmission",
+              "fullType": "vega.commands.v1.WithdrawSubmission",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PrepareWithdrawResponse",
+          "longName": "PrepareWithdrawResponse",
+          "fullName": "api.v1.PrepareWithdrawResponse",
+          "description": "Response for preparing a withdrawal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "blob",
+              "description": "Blob is an encoded representation of the withdrawal ready to sign using the Vega Wallet and then submit as a transaction",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PropagateChainEventRequest",
+          "longName": "PropagateChainEventRequest",
+          "fullName": "api.v1.PropagateChainEventRequest",
+          "description": "Request for a new event sent by the blockchain queue to be propagated on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "evt",
+              "description": "Chain event",
+              "label": "",
+              "type": "ChainEvent",
+              "longType": "vega.commands.v1.ChainEvent",
+              "fullType": "vega.commands.v1.ChainEvent",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pub_key",
+              "description": "Public key",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "signature",
+              "description": "Signature",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PropagateChainEventResponse",
+          "longName": "PropagateChainEventResponse",
+          "fullName": "api.v1.PropagateChainEventResponse",
+          "description": "Response for a new event sent by the blockchain queue to be propagated on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "success",
+              "description": "Success will be true if the event was accepted by the node,\n**Important** - success does not mean that the event is confirmed by consensus",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "StatisticsRequest",
+          "longName": "StatisticsRequest",
+          "fullName": "api.v1.StatisticsRequest",
+          "description": "A a request for statistics about the Vega network",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "StatisticsResponse",
+          "longName": "StatisticsResponse",
+          "fullName": "api.v1.StatisticsResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "statistics",
+              "description": "",
+              "label": "",
+              "type": "Statistics",
+              "longType": "vega.Statistics",
+              "fullType": "vega.Statistics",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SubmitTransactionRequest",
+          "longName": "SubmitTransactionRequest",
+          "fullName": "api.v1.SubmitTransactionRequest",
+          "description": "Request for submitting a transaction on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tx",
+              "description": "A bundle of signed payload and signature, to form a transaction that will be submitted to the Vega blockchain",
+              "label": "",
+              "type": "SignedBundle",
+              "longType": "vega.SignedBundle",
+              "fullType": "vega.SignedBundle",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "type",
+              "description": "Type of transaction request, for example ASYNC, meaning the transaction will be submitted and not block on a response",
+              "label": "",
+              "type": "Type",
+              "longType": "SubmitTransactionRequest.Type",
+              "fullType": "api.v1.SubmitTransactionRequest.Type",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "SubmitTransactionResponse",
+          "longName": "SubmitTransactionResponse",
+          "fullName": "api.v1.SubmitTransactionResponse",
+          "description": "Response for submitting a transaction on Vega",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "success",
+              "description": "Success will be true if the transaction was accepted by the node,\n**Important** - success does not mean that the event is confirmed by consensus",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByMarketRequest",
+          "longName": "TradesByMarketRequest",
+          "fullName": "api.v1.TradesByMarketRequest",
+          "description": "Request for a list of trades on a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "pagination",
+              "description": "Pagination controls",
+              "label": "",
+              "type": "Pagination",
+              "longType": "Pagination",
+              "fullType": "api.v1.Pagination",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByMarketResponse",
+          "longName": "TradesByMarketResponse",
+          "fullName": "api.v1.TradesByMarketResponse",
+          "description": "Response for a list of trades on a market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trades",
+              "description": "A list of 0 or more trades",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByOrderRequest",
+          "longName": "TradesByOrderRequest",
+          "fullName": "api.v1.TradesByOrderRequest",
+          "description": "Request for a list of trades related to an order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "order_id",
+              "description": "Order identifier, required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByOrderResponse",
+          "longName": "TradesByOrderResponse",
+          "fullName": "api.v1.TradesByOrderResponse",
+          "description": "Response for a list of trades related to an order",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trades",
+              "description": "A list of 0 or more trades",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByPartyRequest",
+          "longName": "TradesByPartyRequest",
+          "fullName": "api.v1.TradesByPartyRequest",
+          "description": "Request for a list of trades relating to the given party\nOptionally, the list can be additionally filtered for trades by market",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "Party identifier. Required field",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "pagination",
+              "description": "Pagination controls",
+              "label": "",
+              "type": "Pagination",
+              "longType": "Pagination",
+              "fullType": "api.v1.Pagination",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesByPartyResponse",
+          "longName": "TradesByPartyResponse",
+          "fullName": "api.v1.TradesByPartyResponse",
+          "description": "Response for a list of trades relating to a party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trades",
+              "description": "A list of 0 or more trades",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesSubscribeRequest",
+          "longName": "TradesSubscribeRequest",
+          "fullName": "api.v1.TradesSubscribeRequest",
+          "description": "Request to subscribe to a stream of (Trades)[#vega.Trade]",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "market_id",
+              "description": "Market identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "party_id",
+              "description": "Party identifier",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TradesSubscribeResponse",
+          "longName": "TradesSubscribeResponse",
+          "fullName": "api.v1.TradesSubscribeResponse",
+          "description": "A stream of trades",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "trades",
+              "description": "A list of 0 or more trades",
+              "label": "repeated",
+              "type": "Trade",
+              "longType": "vega.Trade",
+              "fullType": "vega.Trade",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransferResponsesSubscribeRequest",
+          "longName": "TransferResponsesSubscribeRequest",
+          "fullName": "api.v1.TransferResponsesSubscribeRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "TransferResponsesSubscribeResponse",
+          "longName": "TransferResponsesSubscribeResponse",
+          "fullName": "api.v1.TransferResponsesSubscribeResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "response",
+              "description": "",
+              "label": "",
+              "type": "TransferResponse",
+              "longType": "vega.TransferResponse",
+              "fullType": "vega.TransferResponse",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WithdrawalRequest",
+          "longName": "WithdrawalRequest",
+          "fullName": "api.v1.WithdrawalRequest",
+          "description": "A request to get a specific withdrawal by identifier",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The identifier of the withdrawal",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "WithdrawalResponse",
+          "longName": "WithdrawalResponse",
+          "fullName": "api.v1.WithdrawalResponse",
+          "description": "A response for a withdrawal",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "withdrawal",
+              "description": "The withdrawal matching the identifier from the request",
+              "label": "",
+              "type": "Withdrawal",
+              "longType": "vega.Withdrawal",
+              "fullType": "vega.Withdrawal",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "WithdrawalsRequest",
+          "longName": "WithdrawalsRequest",
+          "fullName": "api.v1.WithdrawalsRequest",
+          "description": "A request to get a list of withdrawal from a given party",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "party_id",
+              "description": "The party to get the withdrawals for",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": "",
+              "options": {
+                "validator.field": [
+                  {
+                    "name": "string_not_empty",
+                    "value": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "WithdrawalsResponse",
+          "longName": "WithdrawalsResponse",
+          "fullName": "api.v1.WithdrawalsResponse",
+          "description": "The response for a list of withdrawals",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "withdrawals",
+              "description": "The list of withdrawals for the specified party",
+              "label": "repeated",
+              "type": "Withdrawal",
+              "longType": "vega.Withdrawal",
+              "fullType": "vega.Withdrawal",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "name": "TradingDataService",
+          "longName": "TradingDataService",
+          "fullName": "api.v1.TradingDataService",
+          "description": "",
+          "methods": [
+            {
+              "name": "MarketAccounts",
+              "description": "Get a list of Accounts by Market",
+              "requestType": "MarketAccountsRequest",
+              "requestLongType": "MarketAccountsRequest",
+              "requestFullType": "api.v1.MarketAccountsRequest",
+              "requestStreaming": false,
+              "responseType": "MarketAccountsResponse",
+              "responseLongType": "MarketAccountsResponse",
+              "responseFullType": "api.v1.MarketAccountsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PartyAccounts",
+              "description": "Get a list of Accounts by Party",
+              "requestType": "PartyAccountsRequest",
+              "requestLongType": "PartyAccountsRequest",
+              "requestFullType": "api.v1.PartyAccountsRequest",
+              "requestStreaming": false,
+              "responseType": "PartyAccountsResponse",
+              "responseLongType": "PartyAccountsResponse",
+              "responseFullType": "api.v1.PartyAccountsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "FeeInfrastructureAccounts",
+              "description": "Get a list of accounts holding infrastructure fees.\nCan be filtered by asset, there will be 1 infrastructure fee account per\nasset in the network.",
+              "requestType": "FeeInfrastructureAccountsRequest",
+              "requestLongType": "FeeInfrastructureAccountsRequest",
+              "requestFullType": "api.v1.FeeInfrastructureAccountsRequest",
+              "requestStreaming": false,
+              "responseType": "FeeInfrastructureAccountsResponse",
+              "responseLongType": "FeeInfrastructureAccountsResponse",
+              "responseFullType": "api.v1.FeeInfrastructureAccountsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Candles",
+              "description": "Get a list of Candles by Market",
+              "requestType": "CandlesRequest",
+              "requestLongType": "CandlesRequest",
+              "requestFullType": "api.v1.CandlesRequest",
+              "requestStreaming": false,
+              "responseType": "CandlesResponse",
+              "responseLongType": "CandlesResponse",
+              "responseFullType": "api.v1.CandlesResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "MarketDataByID",
+              "description": "Get Market Data by Market ID",
+              "requestType": "MarketDataByIDRequest",
+              "requestLongType": "MarketDataByIDRequest",
+              "requestFullType": "api.v1.MarketDataByIDRequest",
+              "requestStreaming": false,
+              "responseType": "MarketDataByIDResponse",
+              "responseLongType": "MarketDataByIDResponse",
+              "responseFullType": "api.v1.MarketDataByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "MarketsData",
+              "description": "Get a list of Market Data",
+              "requestType": "MarketsDataRequest",
+              "requestLongType": "MarketsDataRequest",
+              "requestFullType": "api.v1.MarketsDataRequest",
+              "requestStreaming": false,
+              "responseType": "MarketsDataResponse",
+              "responseLongType": "MarketsDataResponse",
+              "responseFullType": "api.v1.MarketsDataResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "MarketByID",
+              "description": "Get a Market by ID",
+              "requestType": "MarketByIDRequest",
+              "requestLongType": "MarketByIDRequest",
+              "requestFullType": "api.v1.MarketByIDRequest",
+              "requestStreaming": false,
+              "responseType": "MarketByIDResponse",
+              "responseLongType": "MarketByIDResponse",
+              "responseFullType": "api.v1.MarketByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "MarketDepth",
+              "description": "Get Market Depth",
+              "requestType": "MarketDepthRequest",
+              "requestLongType": "MarketDepthRequest",
+              "requestFullType": "api.v1.MarketDepthRequest",
+              "requestStreaming": false,
+              "responseType": "MarketDepthResponse",
+              "responseLongType": "MarketDepthResponse",
+              "responseFullType": "api.v1.MarketDepthResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Markets",
+              "description": "Get a list of Markets",
+              "requestType": "MarketsRequest",
+              "requestLongType": "MarketsRequest",
+              "requestFullType": "api.v1.MarketsRequest",
+              "requestStreaming": false,
+              "responseType": "MarketsResponse",
+              "responseLongType": "MarketsResponse",
+              "responseFullType": "api.v1.MarketsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrderByMarketAndID",
+              "description": "Get an Order by Market and Order ID",
+              "requestType": "OrderByMarketAndIDRequest",
+              "requestLongType": "OrderByMarketAndIDRequest",
+              "requestFullType": "api.v1.OrderByMarketAndIDRequest",
+              "requestStreaming": false,
+              "responseType": "OrderByMarketAndIDResponse",
+              "responseLongType": "OrderByMarketAndIDResponse",
+              "responseFullType": "api.v1.OrderByMarketAndIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrderByReference",
+              "description": "Get an Order by Pending Order reference (UUID)",
+              "requestType": "OrderByReferenceRequest",
+              "requestLongType": "OrderByReferenceRequest",
+              "requestFullType": "api.v1.OrderByReferenceRequest",
+              "requestStreaming": false,
+              "responseType": "OrderByReferenceResponse",
+              "responseLongType": "OrderByReferenceResponse",
+              "responseFullType": "api.v1.OrderByReferenceResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrdersByMarket",
+              "description": "Get a list of Orders by Market",
+              "requestType": "OrdersByMarketRequest",
+              "requestLongType": "OrdersByMarketRequest",
+              "requestFullType": "api.v1.OrdersByMarketRequest",
+              "requestStreaming": false,
+              "responseType": "OrdersByMarketResponse",
+              "responseLongType": "OrdersByMarketResponse",
+              "responseFullType": "api.v1.OrdersByMarketResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrdersByParty",
+              "description": "Get a list of Orders by Party",
+              "requestType": "OrdersByPartyRequest",
+              "requestLongType": "OrdersByPartyRequest",
+              "requestFullType": "api.v1.OrdersByPartyRequest",
+              "requestStreaming": false,
+              "responseType": "OrdersByPartyResponse",
+              "responseLongType": "OrdersByPartyResponse",
+              "responseFullType": "api.v1.OrdersByPartyResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrderByID",
+              "description": "Get a specific order by order ID",
+              "requestType": "OrderByIDRequest",
+              "requestLongType": "OrderByIDRequest",
+              "requestFullType": "api.v1.OrderByIDRequest",
+              "requestStreaming": false,
+              "responseType": "OrderByIDResponse",
+              "responseLongType": "OrderByIDResponse",
+              "responseFullType": "api.v1.OrderByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OrderVersionsByID",
+              "description": "Get all versions of the order by its orderID",
+              "requestType": "OrderVersionsByIDRequest",
+              "requestLongType": "OrderVersionsByIDRequest",
+              "requestFullType": "api.v1.OrderVersionsByIDRequest",
+              "requestStreaming": false,
+              "responseType": "OrderVersionsByIDResponse",
+              "responseLongType": "OrderVersionsByIDResponse",
+              "responseFullType": "api.v1.OrderVersionsByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "MarginLevels",
+              "description": "Get Margin Levels by Party ID",
+              "requestType": "MarginLevelsRequest",
+              "requestLongType": "MarginLevelsRequest",
+              "requestFullType": "api.v1.MarginLevelsRequest",
+              "requestStreaming": false,
+              "responseType": "MarginLevelsResponse",
+              "responseLongType": "MarginLevelsResponse",
+              "responseFullType": "api.v1.MarginLevelsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Parties",
+              "description": "Get a list of Parties",
+              "requestType": "PartiesRequest",
+              "requestLongType": "PartiesRequest",
+              "requestFullType": "api.v1.PartiesRequest",
+              "requestStreaming": false,
+              "responseType": "PartiesResponse",
+              "responseLongType": "PartiesResponse",
+              "responseFullType": "api.v1.PartiesResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PartyByID",
+              "description": "Get a Party by ID",
+              "requestType": "PartyByIDRequest",
+              "requestLongType": "PartyByIDRequest",
+              "requestFullType": "api.v1.PartyByIDRequest",
+              "requestStreaming": false,
+              "responseType": "PartyByIDResponse",
+              "responseLongType": "PartyByIDResponse",
+              "responseFullType": "api.v1.PartyByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PositionsByParty",
+              "description": "Get a list of Positions by Party",
+              "requestType": "PositionsByPartyRequest",
+              "requestLongType": "PositionsByPartyRequest",
+              "requestFullType": "api.v1.PositionsByPartyRequest",
+              "requestStreaming": false,
+              "responseType": "PositionsByPartyResponse",
+              "responseLongType": "PositionsByPartyResponse",
+              "responseFullType": "api.v1.PositionsByPartyResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "LastTrade",
+              "description": "Get latest Trade",
+              "requestType": "LastTradeRequest",
+              "requestLongType": "LastTradeRequest",
+              "requestFullType": "api.v1.LastTradeRequest",
+              "requestStreaming": false,
+              "responseType": "LastTradeResponse",
+              "responseLongType": "LastTradeResponse",
+              "responseFullType": "api.v1.LastTradeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "TradesByMarket",
+              "description": "Get a list of Trades by Market",
+              "requestType": "TradesByMarketRequest",
+              "requestLongType": "TradesByMarketRequest",
+              "requestFullType": "api.v1.TradesByMarketRequest",
+              "requestStreaming": false,
+              "responseType": "TradesByMarketResponse",
+              "responseLongType": "TradesByMarketResponse",
+              "responseFullType": "api.v1.TradesByMarketResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "TradesByOrder",
+              "description": "Get a list of Trades by Order",
+              "requestType": "TradesByOrderRequest",
+              "requestLongType": "TradesByOrderRequest",
+              "requestFullType": "api.v1.TradesByOrderRequest",
+              "requestStreaming": false,
+              "responseType": "TradesByOrderResponse",
+              "responseLongType": "TradesByOrderResponse",
+              "responseFullType": "api.v1.TradesByOrderResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "TradesByParty",
+              "description": "Get a list of Trades by Party",
+              "requestType": "TradesByPartyRequest",
+              "requestLongType": "TradesByPartyRequest",
+              "requestFullType": "api.v1.TradesByPartyRequest",
+              "requestStreaming": false,
+              "responseType": "TradesByPartyResponse",
+              "responseLongType": "TradesByPartyResponse",
+              "responseFullType": "api.v1.TradesByPartyResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetProposals",
+              "description": "Get governance data (proposals and votes) for all proposals",
+              "requestType": "GetProposalsRequest",
+              "requestLongType": "GetProposalsRequest",
+              "requestFullType": "api.v1.GetProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "GetProposalsResponse",
+              "responseLongType": "GetProposalsResponse",
+              "responseFullType": "api.v1.GetProposalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetProposalsByParty",
+              "description": "Get governance data (proposals and votes) for proposals by party authoring them",
+              "requestType": "GetProposalsByPartyRequest",
+              "requestLongType": "GetProposalsByPartyRequest",
+              "requestFullType": "api.v1.GetProposalsByPartyRequest",
+              "requestStreaming": false,
+              "responseType": "GetProposalsByPartyResponse",
+              "responseLongType": "GetProposalsByPartyResponse",
+              "responseFullType": "api.v1.GetProposalsByPartyResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetVotesByParty",
+              "description": "Get votes by party casting them",
+              "requestType": "GetVotesByPartyRequest",
+              "requestLongType": "GetVotesByPartyRequest",
+              "requestFullType": "api.v1.GetVotesByPartyRequest",
+              "requestStreaming": false,
+              "responseType": "GetVotesByPartyResponse",
+              "responseLongType": "GetVotesByPartyResponse",
+              "responseFullType": "api.v1.GetVotesByPartyResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetNewMarketProposals",
+              "description": "Get governance data (proposals and votes) for proposals that aim creating new markets",
+              "requestType": "GetNewMarketProposalsRequest",
+              "requestLongType": "GetNewMarketProposalsRequest",
+              "requestFullType": "api.v1.GetNewMarketProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "GetNewMarketProposalsResponse",
+              "responseLongType": "GetNewMarketProposalsResponse",
+              "responseFullType": "api.v1.GetNewMarketProposalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetUpdateMarketProposals",
+              "description": "Get governance data (proposals and votes) for proposals that aim updating markets",
+              "requestType": "GetUpdateMarketProposalsRequest",
+              "requestLongType": "GetUpdateMarketProposalsRequest",
+              "requestFullType": "api.v1.GetUpdateMarketProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "GetUpdateMarketProposalsResponse",
+              "responseLongType": "GetUpdateMarketProposalsResponse",
+              "responseFullType": "api.v1.GetUpdateMarketProposalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetNetworkParametersProposals",
+              "description": "Get governance data (proposals and votes) for proposals that aim updating Vega network parameters",
+              "requestType": "GetNetworkParametersProposalsRequest",
+              "requestLongType": "GetNetworkParametersProposalsRequest",
+              "requestFullType": "api.v1.GetNetworkParametersProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "GetNetworkParametersProposalsResponse",
+              "responseLongType": "GetNetworkParametersProposalsResponse",
+              "responseFullType": "api.v1.GetNetworkParametersProposalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetNewAssetProposals",
+              "description": "Get governance data (proposals and votes) for proposals aiming to create new assets",
+              "requestType": "GetNewAssetProposalsRequest",
+              "requestLongType": "GetNewAssetProposalsRequest",
+              "requestFullType": "api.v1.GetNewAssetProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "GetNewAssetProposalsResponse",
+              "responseLongType": "GetNewAssetProposalsResponse",
+              "responseFullType": "api.v1.GetNewAssetProposalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetProposalByID",
+              "description": "Get governance data (proposals and votes) for a proposal located by ID",
+              "requestType": "GetProposalByIDRequest",
+              "requestLongType": "GetProposalByIDRequest",
+              "requestFullType": "api.v1.GetProposalByIDRequest",
+              "requestStreaming": false,
+              "responseType": "GetProposalByIDResponse",
+              "responseLongType": "GetProposalByIDResponse",
+              "responseFullType": "api.v1.GetProposalByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetProposalByReference",
+              "description": "Get governance data (proposals and votes) for a proposal located by reference",
+              "requestType": "GetProposalByReferenceRequest",
+              "requestLongType": "GetProposalByReferenceRequest",
+              "requestFullType": "api.v1.GetProposalByReferenceRequest",
+              "requestStreaming": false,
+              "responseType": "GetProposalByReferenceResponse",
+              "responseLongType": "GetProposalByReferenceResponse",
+              "responseFullType": "api.v1.GetProposalByReferenceResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ObserveGovernance",
+              "description": "Subscribe to a stream of all governance updates",
+              "requestType": "ObserveGovernanceRequest",
+              "requestLongType": "ObserveGovernanceRequest",
+              "requestFullType": "api.v1.ObserveGovernanceRequest",
+              "requestStreaming": false,
+              "responseType": "ObserveGovernanceResponse",
+              "responseLongType": "ObserveGovernanceResponse",
+              "responseFullType": "api.v1.ObserveGovernanceResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "ObservePartyProposals",
+              "description": "Subscribe to a stream of proposal updates",
+              "requestType": "ObservePartyProposalsRequest",
+              "requestLongType": "ObservePartyProposalsRequest",
+              "requestFullType": "api.v1.ObservePartyProposalsRequest",
+              "requestStreaming": false,
+              "responseType": "ObservePartyProposalsResponse",
+              "responseLongType": "ObservePartyProposalsResponse",
+              "responseFullType": "api.v1.ObservePartyProposalsResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "ObservePartyVotes",
+              "description": "Subscribe to a stream of votes cast by a specific party",
+              "requestType": "ObservePartyVotesRequest",
+              "requestLongType": "ObservePartyVotesRequest",
+              "requestFullType": "api.v1.ObservePartyVotesRequest",
+              "requestStreaming": false,
+              "responseType": "ObservePartyVotesResponse",
+              "responseLongType": "ObservePartyVotesResponse",
+              "responseFullType": "api.v1.ObservePartyVotesResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "ObserveProposalVotes",
+              "description": "Subscribe to a stream of proposal votes",
+              "requestType": "ObserveProposalVotesRequest",
+              "requestLongType": "ObserveProposalVotesRequest",
+              "requestFullType": "api.v1.ObserveProposalVotesRequest",
+              "requestStreaming": false,
+              "responseType": "ObserveProposalVotesResponse",
+              "responseLongType": "ObserveProposalVotesResponse",
+              "responseFullType": "api.v1.ObserveProposalVotesResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "ObserveEventBus",
+              "description": "Subscribe to a stream of events from the core",
+              "requestType": "ObserveEventBusRequest",
+              "requestLongType": "ObserveEventBusRequest",
+              "requestFullType": "api.v1.ObserveEventBusRequest",
+              "requestStreaming": true,
+              "responseType": "ObserveEventBusResponse",
+              "responseLongType": "ObserveEventBusResponse",
+              "responseFullType": "api.v1.ObserveEventBusResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "Statistics",
+              "description": "Get Statistics on Vega",
+              "requestType": "StatisticsRequest",
+              "requestLongType": "StatisticsRequest",
+              "requestFullType": "api.v1.StatisticsRequest",
+              "requestStreaming": false,
+              "responseType": "StatisticsResponse",
+              "responseLongType": "StatisticsResponse",
+              "responseFullType": "api.v1.StatisticsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "GetVegaTime",
+              "description": "Get Time",
+              "requestType": "GetVegaTimeRequest",
+              "requestLongType": "GetVegaTimeRequest",
+              "requestFullType": "api.v1.GetVegaTimeRequest",
+              "requestStreaming": false,
+              "responseType": "GetVegaTimeResponse",
+              "responseLongType": "GetVegaTimeResponse",
+              "responseFullType": "api.v1.GetVegaTimeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "AccountsSubscribe",
+              "description": "Subscribe to a stream of Accounts",
+              "requestType": "AccountsSubscribeRequest",
+              "requestLongType": "AccountsSubscribeRequest",
+              "requestFullType": "api.v1.AccountsSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "AccountsSubscribeResponse",
+              "responseLongType": "AccountsSubscribeResponse",
+              "responseFullType": "api.v1.AccountsSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "CandlesSubscribe",
+              "description": "Subscribe to a stream of Candles",
+              "requestType": "CandlesSubscribeRequest",
+              "requestLongType": "CandlesSubscribeRequest",
+              "requestFullType": "api.v1.CandlesSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "CandlesSubscribeResponse",
+              "responseLongType": "CandlesSubscribeResponse",
+              "responseFullType": "api.v1.CandlesSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "MarginLevelsSubscribe",
+              "description": "Subscribe to a stream of Margin Levels",
+              "requestType": "MarginLevelsSubscribeRequest",
+              "requestLongType": "MarginLevelsSubscribeRequest",
+              "requestFullType": "api.v1.MarginLevelsSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "MarginLevelsSubscribeResponse",
+              "responseLongType": "MarginLevelsSubscribeResponse",
+              "responseFullType": "api.v1.MarginLevelsSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "MarketDepthSubscribe",
+              "description": "Subscribe to a stream of Market Depth",
+              "requestType": "MarketDepthSubscribeRequest",
+              "requestLongType": "MarketDepthSubscribeRequest",
+              "requestFullType": "api.v1.MarketDepthSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "MarketDepthSubscribeResponse",
+              "responseLongType": "MarketDepthSubscribeResponse",
+              "responseFullType": "api.v1.MarketDepthSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "MarketDepthUpdatesSubscribe",
+              "description": "Subscribe to a stream of Market Depth Price Level Updates",
+              "requestType": "MarketDepthUpdatesSubscribeRequest",
+              "requestLongType": "MarketDepthUpdatesSubscribeRequest",
+              "requestFullType": "api.v1.MarketDepthUpdatesSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "MarketDepthUpdatesSubscribeResponse",
+              "responseLongType": "MarketDepthUpdatesSubscribeResponse",
+              "responseFullType": "api.v1.MarketDepthUpdatesSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "MarketsDataSubscribe",
+              "description": "Subscribe to a stream of Markets Data",
+              "requestType": "MarketsDataSubscribeRequest",
+              "requestLongType": "MarketsDataSubscribeRequest",
+              "requestFullType": "api.v1.MarketsDataSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "MarketsDataSubscribeResponse",
+              "responseLongType": "MarketsDataSubscribeResponse",
+              "responseFullType": "api.v1.MarketsDataSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "OrdersSubscribe",
+              "description": "Subscribe to a stream of Orders",
+              "requestType": "OrdersSubscribeRequest",
+              "requestLongType": "OrdersSubscribeRequest",
+              "requestFullType": "api.v1.OrdersSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "OrdersSubscribeResponse",
+              "responseLongType": "OrdersSubscribeResponse",
+              "responseFullType": "api.v1.OrdersSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "PositionsSubscribe",
+              "description": "Subscribe to a stream of Positions",
+              "requestType": "PositionsSubscribeRequest",
+              "requestLongType": "PositionsSubscribeRequest",
+              "requestFullType": "api.v1.PositionsSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "PositionsSubscribeResponse",
+              "responseLongType": "PositionsSubscribeResponse",
+              "responseFullType": "api.v1.PositionsSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "TradesSubscribe",
+              "description": "Subscribe to a stream of Trades",
+              "requestType": "TradesSubscribeRequest",
+              "requestLongType": "TradesSubscribeRequest",
+              "requestFullType": "api.v1.TradesSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "TradesSubscribeResponse",
+              "responseLongType": "TradesSubscribeResponse",
+              "responseFullType": "api.v1.TradesSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "TransferResponsesSubscribe",
+              "description": "Subscribe to a stream of Transfer Responses",
+              "requestType": "TransferResponsesSubscribeRequest",
+              "requestLongType": "TransferResponsesSubscribeRequest",
+              "requestFullType": "api.v1.TransferResponsesSubscribeRequest",
+              "requestStreaming": false,
+              "responseType": "TransferResponsesSubscribeResponse",
+              "responseLongType": "TransferResponsesSubscribeResponse",
+              "responseFullType": "api.v1.TransferResponsesSubscribeResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "GetNodeSignaturesAggregate",
+              "description": "Get an aggregate of signatures from all the nodes of the network",
+              "requestType": "GetNodeSignaturesAggregateRequest",
+              "requestLongType": "GetNodeSignaturesAggregateRequest",
+              "requestFullType": "api.v1.GetNodeSignaturesAggregateRequest",
+              "requestStreaming": false,
+              "responseType": "GetNodeSignaturesAggregateResponse",
+              "responseLongType": "GetNodeSignaturesAggregateResponse",
+              "responseFullType": "api.v1.GetNodeSignaturesAggregateResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "AssetByID",
+              "description": "Get an asset by its identifier",
+              "requestType": "AssetByIDRequest",
+              "requestLongType": "AssetByIDRequest",
+              "requestFullType": "api.v1.AssetByIDRequest",
+              "requestStreaming": false,
+              "responseType": "AssetByIDResponse",
+              "responseLongType": "AssetByIDResponse",
+              "responseFullType": "api.v1.AssetByIDResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Assets",
+              "description": "Get a list of all assets on Vega",
+              "requestType": "AssetsRequest",
+              "requestLongType": "AssetsRequest",
+              "requestFullType": "api.v1.AssetsRequest",
+              "requestStreaming": false,
+              "responseType": "AssetsResponse",
+              "responseLongType": "AssetsResponse",
+              "responseFullType": "api.v1.AssetsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "EstimateFee",
+              "description": "Get an estimate for the fee to be paid for a given order",
+              "requestType": "EstimateFeeRequest",
+              "requestLongType": "EstimateFeeRequest",
+              "requestFullType": "api.v1.EstimateFeeRequest",
+              "requestStreaming": false,
+              "responseType": "EstimateFeeResponse",
+              "responseLongType": "EstimateFeeResponse",
+              "responseFullType": "api.v1.EstimateFeeResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "EstimateMargin",
+              "description": "Get an estimate for the margin required for a new order",
+              "requestType": "EstimateMarginRequest",
+              "requestLongType": "EstimateMarginRequest",
+              "requestFullType": "api.v1.EstimateMarginRequest",
+              "requestStreaming": false,
+              "responseType": "EstimateMarginResponse",
+              "responseLongType": "EstimateMarginResponse",
+              "responseFullType": "api.v1.EstimateMarginResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "ERC20WithdrawalApproval",
+              "description": "Get the bundle approval for an ERC20 withdrawal,\nthese data are being used to bundle the call to the smart contract on the ethereum bridge",
+              "requestType": "ERC20WithdrawalApprovalRequest",
+              "requestLongType": "ERC20WithdrawalApprovalRequest",
+              "requestFullType": "api.v1.ERC20WithdrawalApprovalRequest",
+              "requestStreaming": false,
+              "responseType": "ERC20WithdrawalApprovalResponse",
+              "responseLongType": "ERC20WithdrawalApprovalResponse",
+              "responseFullType": "api.v1.ERC20WithdrawalApprovalResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Withdrawal",
+              "description": "Get a withdrawal by its identifier",
+              "requestType": "WithdrawalRequest",
+              "requestLongType": "WithdrawalRequest",
+              "requestFullType": "api.v1.WithdrawalRequest",
+              "requestStreaming": false,
+              "responseType": "WithdrawalResponse",
+              "responseLongType": "WithdrawalResponse",
+              "responseFullType": "api.v1.WithdrawalResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Withdrawals",
+              "description": "Get withdrawals for a party",
+              "requestType": "WithdrawalsRequest",
+              "requestLongType": "WithdrawalsRequest",
+              "requestFullType": "api.v1.WithdrawalsRequest",
+              "requestStreaming": false,
+              "responseType": "WithdrawalsResponse",
+              "responseLongType": "WithdrawalsResponse",
+              "responseFullType": "api.v1.WithdrawalsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Deposit",
+              "description": "Get a deposit by its identifier",
+              "requestType": "DepositRequest",
+              "requestLongType": "DepositRequest",
+              "requestFullType": "api.v1.DepositRequest",
+              "requestStreaming": false,
+              "responseType": "DepositResponse",
+              "responseLongType": "DepositResponse",
+              "responseFullType": "api.v1.DepositResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "Deposits",
+              "description": "Get deposits for a party",
+              "requestType": "DepositsRequest",
+              "requestLongType": "DepositsRequest",
+              "requestFullType": "api.v1.DepositsRequest",
+              "requestStreaming": false,
+              "responseType": "DepositsResponse",
+              "responseLongType": "DepositsResponse",
+              "responseFullType": "api.v1.DepositsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "NetworkParameters",
+              "description": "Get the network parameters",
+              "requestType": "NetworkParametersRequest",
+              "requestLongType": "NetworkParametersRequest",
+              "requestFullType": "api.v1.NetworkParametersRequest",
+              "requestStreaming": false,
+              "responseType": "NetworkParametersResponse",
+              "responseLongType": "NetworkParametersResponse",
+              "responseFullType": "api.v1.NetworkParametersResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "LiquidityProvisions",
+              "description": "Get the liquidity provision orders",
+              "requestType": "LiquidityProvisionsRequest",
+              "requestLongType": "LiquidityProvisionsRequest",
+              "requestFullType": "api.v1.LiquidityProvisionsRequest",
+              "requestStreaming": false,
+              "responseType": "LiquidityProvisionsResponse",
+              "responseLongType": "LiquidityProvisionsResponse",
+              "responseFullType": "api.v1.LiquidityProvisionsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OracleSpec",
+              "description": "Get an oracle spec by ID",
+              "requestType": "OracleSpecRequest",
+              "requestLongType": "OracleSpecRequest",
+              "requestFullType": "api.v1.OracleSpecRequest",
+              "requestStreaming": false,
+              "responseType": "OracleSpecResponse",
+              "responseLongType": "OracleSpecResponse",
+              "responseFullType": "api.v1.OracleSpecResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OracleSpecs",
+              "description": "Get the oracle specs",
+              "requestType": "OracleSpecsRequest",
+              "requestLongType": "OracleSpecsRequest",
+              "requestFullType": "api.v1.OracleSpecsRequest",
+              "requestStreaming": false,
+              "responseType": "OracleSpecsResponse",
+              "responseLongType": "OracleSpecsResponse",
+              "responseFullType": "api.v1.OracleSpecsResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "OracleDataBySpec",
+              "description": "Get all oracle data",
+              "requestType": "OracleDataBySpecRequest",
+              "requestLongType": "OracleDataBySpecRequest",
+              "requestFullType": "api.v1.OracleDataBySpecRequest",
+              "requestStreaming": false,
+              "responseType": "OracleDataBySpecResponse",
+              "responseLongType": "OracleDataBySpecResponse",
+              "responseFullType": "api.v1.OracleDataBySpecResponse",
+              "responseStreaming": false
+            }
+          ]
+        },
+        {
+          "name": "TradingService",
+          "longName": "TradingService",
+          "fullName": "api.v1.TradingService",
+          "description": "",
+          "methods": [
+            {
+              "name": "PrepareSubmitOrder",
+              "description": "Prepare a submit order request",
+              "requestType": "PrepareSubmitOrderRequest",
+              "requestLongType": "PrepareSubmitOrderRequest",
+              "requestFullType": "api.v1.PrepareSubmitOrderRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareSubmitOrderResponse",
+              "responseLongType": "PrepareSubmitOrderResponse",
+              "responseFullType": "api.v1.PrepareSubmitOrderResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareCancelOrder",
+              "description": "Prepare a cancel order request",
+              "requestType": "PrepareCancelOrderRequest",
+              "requestLongType": "PrepareCancelOrderRequest",
+              "requestFullType": "api.v1.PrepareCancelOrderRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareCancelOrderResponse",
+              "responseLongType": "PrepareCancelOrderResponse",
+              "responseFullType": "api.v1.PrepareCancelOrderResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareAmendOrder",
+              "description": "Prepare an amend order request",
+              "requestType": "PrepareAmendOrderRequest",
+              "requestLongType": "PrepareAmendOrderRequest",
+              "requestFullType": "api.v1.PrepareAmendOrderRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareAmendOrderResponse",
+              "responseLongType": "PrepareAmendOrderResponse",
+              "responseFullType": "api.v1.PrepareAmendOrderResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareWithdraw",
+              "description": "Request a withdrawal",
+              "requestType": "PrepareWithdrawRequest",
+              "requestLongType": "PrepareWithdrawRequest",
+              "requestFullType": "api.v1.PrepareWithdrawRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareWithdrawResponse",
+              "responseLongType": "PrepareWithdrawResponse",
+              "responseFullType": "api.v1.PrepareWithdrawResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "SubmitTransaction",
+              "description": "Submit a signed transaction",
+              "requestType": "SubmitTransactionRequest",
+              "requestLongType": "SubmitTransactionRequest",
+              "requestFullType": "api.v1.SubmitTransactionRequest",
+              "requestStreaming": false,
+              "responseType": "SubmitTransactionResponse",
+              "responseLongType": "SubmitTransactionResponse",
+              "responseFullType": "api.v1.SubmitTransactionResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareProposalSubmission",
+              "description": "Prepare a governance proposal",
+              "requestType": "PrepareProposalSubmissionRequest",
+              "requestLongType": "PrepareProposalSubmissionRequest",
+              "requestFullType": "api.v1.PrepareProposalSubmissionRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareProposalSubmissionResponse",
+              "responseLongType": "PrepareProposalSubmissionResponse",
+              "responseFullType": "api.v1.PrepareProposalSubmissionResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareVoteSubmission",
+              "description": "Prepare a governance vote",
+              "requestType": "PrepareVoteSubmissionRequest",
+              "requestLongType": "PrepareVoteSubmissionRequest",
+              "requestFullType": "api.v1.PrepareVoteSubmissionRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareVoteSubmissionResponse",
+              "responseLongType": "PrepareVoteSubmissionResponse",
+              "responseFullType": "api.v1.PrepareVoteSubmissionResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PropagateChainEvent",
+              "description": "Propagate a chain event",
+              "requestType": "PropagateChainEventRequest",
+              "requestLongType": "PropagateChainEventRequest",
+              "requestFullType": "api.v1.PropagateChainEventRequest",
+              "requestStreaming": false,
+              "responseType": "PropagateChainEventResponse",
+              "responseLongType": "PropagateChainEventResponse",
+              "responseFullType": "api.v1.PropagateChainEventResponse",
+              "responseStreaming": false
+            },
+            {
+              "name": "PrepareLiquidityProvision",
+              "description": "Prepare a liquidity provision request",
+              "requestType": "PrepareLiquidityProvisionRequest",
+              "requestLongType": "PrepareLiquidityProvisionRequest",
+              "requestFullType": "api.v1.PrepareLiquidityProvisionRequest",
+              "requestStreaming": false,
+              "responseType": "PrepareLiquidityProvisionResponse",
+              "responseLongType": "PrepareLiquidityProvisionResponse",
+              "responseFullType": "api.v1.PrepareLiquidityProvisionResponse",
+              "responseStreaming": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "commands/v1/oracles.proto",
+      "description": "",
+      "package": "vega.commands.v1",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "OracleSource",
+          "longName": "OracleDataSubmission.OracleSource",
+          "fullName": "vega.commands.v1.OracleDataSubmission.OracleSource",
+          "description": "The supported Oracle sources",
+          "values": [
+            {
+              "name": "ORACLE_SOURCE_UNSPECIFIED",
+              "number": "0",
+              "description": "The default value"
+            },
+            {
+              "name": "ORACLE_SOURCE_OPEN_ORACLE",
+              "number": "1",
+              "description": "Support for Open Oracle standard"
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "OracleDataSubmission",
+          "longName": "OracleDataSubmission",
+          "fullName": "vega.commands.v1.OracleDataSubmission",
+          "description": "Command to submit new Oracle data from third party providers",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "source",
+              "description": "The source from which the data is coming from",
+              "label": "",
+              "type": "OracleSource",
+              "longType": "OracleDataSubmission.OracleSource",
+              "fullType": "vega.commands.v1.OracleDataSubmission.OracleSource",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "payload",
+              "description": "The data provided by the third party provider",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "tm/replay.proto",
+      "description": "",
+      "package": "tm",
+      "hasEnums": true,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [
+        {
+          "name": "EvidenceType",
+          "longName": "EvidenceType",
+          "fullName": "tm.EvidenceType",
+          "description": "",
+          "values": [
+            {
+              "name": "UNKNOWN",
+              "number": "0",
+              "description": ""
+            },
+            {
+              "name": "DUPLICATE_VOTE",
+              "number": "1",
+              "description": ""
+            },
+            {
+              "name": "LIGHT_CLIENT_ATTACK",
+              "number": "2",
+              "description": ""
+            }
+          ]
+        }
+      ],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "BlockParams",
+          "longName": "BlockParams",
+          "fullName": "tm.BlockParams",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "max_bytes",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_gas",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ConsensusParams",
+          "longName": "ConsensusParams",
+          "fullName": "tm.ConsensusParams",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "block",
+              "description": "",
+              "label": "",
+              "type": "BlockParams",
+              "longType": "BlockParams",
+              "fullType": "tm.BlockParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "evidence",
+              "description": "",
+              "label": "",
+              "type": "EvidenceParams",
+              "longType": "EvidenceParams",
+              "fullType": "tm.EvidenceParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validator",
+              "description": "",
+              "label": "",
+              "type": "ValidatorParams",
+              "longType": "ValidatorParams",
+              "fullType": "tm.ValidatorParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "version",
+              "description": "",
+              "label": "",
+              "type": "VersionParams",
+              "longType": "VersionParams",
+              "fullType": "tm.VersionParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Event",
+          "longName": "Event",
+          "fullName": "tm.Event",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "attributes",
+              "description": "",
+              "label": "repeated",
+              "type": "EventAttribute",
+              "longType": "EventAttribute",
+              "fullType": "tm.EventAttribute",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EventAttribute",
+          "longName": "EventAttribute",
+          "fullName": "tm.EventAttribute",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "value",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "index",
+              "description": "nondeterministic",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Evidence",
+          "longName": "Evidence",
+          "fullName": "tm.Evidence",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "label": "",
+              "type": "EvidenceType",
+              "longType": "EvidenceType",
+              "fullType": "tm.EvidenceType",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validator",
+              "description": "",
+              "label": "",
+              "type": "Validator",
+              "longType": "Validator",
+              "fullType": "tm.Validator",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "height",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "total_voting_power",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "EvidenceParams",
+          "longName": "EvidenceParams",
+          "fullName": "tm.EvidenceParams",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "max_age_num_blocks",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_age_duration",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "max_num",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Header",
+          "longName": "Header",
+          "fullName": "tm.Header",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "chain_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "height",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "time",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "LastCommitInfo",
+          "longName": "LastCommitInfo",
+          "fullName": "tm.LastCommitInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "round",
+              "description": "",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "votes",
+              "description": "",
+              "label": "repeated",
+              "type": "VoteInfo",
+              "longType": "VoteInfo",
+              "fullType": "tm.VoteInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "PublicKey",
+          "longName": "PublicKey",
+          "fullName": "tm.PublicKey",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "ed25519",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "sum",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RequestBeginBlock",
+          "longName": "RequestBeginBlock",
+          "fullName": "tm.RequestBeginBlock",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "hash",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "header",
+              "description": "",
+              "label": "",
+              "type": "Header",
+              "longType": "Header",
+              "fullType": "tm.Header",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "last_commit_info",
+              "description": "",
+              "label": "",
+              "type": "LastCommitInfo",
+              "longType": "LastCommitInfo",
+              "fullType": "tm.LastCommitInfo",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "byzantine_validators",
+              "description": "",
+              "label": "repeated",
+              "type": "Evidence",
+              "longType": "Evidence",
+              "fullType": "tm.Evidence",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RequestDeliverTx",
+          "longName": "RequestDeliverTx",
+          "fullName": "tm.RequestDeliverTx",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "tx",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "RequestInitChain",
+          "longName": "RequestInitChain",
+          "fullName": "tm.RequestInitChain",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "time",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "chain_id",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "consensus_params",
+              "description": "",
+              "label": "",
+              "type": "ConsensusParams",
+              "longType": "ConsensusParams",
+              "fullType": "tm.ConsensusParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validators",
+              "description": "",
+              "label": "repeated",
+              "type": "ValidatorUpdate",
+              "longType": "ValidatorUpdate",
+              "fullType": "tm.ValidatorUpdate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "app_state_bytes",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "initial_height",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ResponseBeginBlock",
+          "longName": "ResponseBeginBlock",
+          "fullName": "tm.ResponseBeginBlock",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "events",
+              "description": "",
+              "label": "repeated",
+              "type": "Event",
+              "longType": "Event",
+              "fullType": "tm.Event",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ResponseDeliverTx",
+          "longName": "ResponseDeliverTx",
+          "fullName": "tm.ResponseDeliverTx",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "code",
+              "description": "",
+              "label": "",
+              "type": "uint32",
+              "longType": "uint32",
+              "fullType": "uint32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "data",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "log",
+              "description": "nondeterministic",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "info",
+              "description": "nondeterministic",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gas_wanted",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "gas_used",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "events",
+              "description": "",
+              "label": "repeated",
+              "type": "Event",
+              "longType": "Event",
+              "fullType": "tm.Event",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "codespace",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ResponseInitChain",
+          "longName": "ResponseInitChain",
+          "fullName": "tm.ResponseInitChain",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "consensus_params",
+              "description": "",
+              "label": "",
+              "type": "ConsensusParams",
+              "longType": "ConsensusParams",
+              "fullType": "tm.ConsensusParams",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "validators",
+              "description": "",
+              "label": "repeated",
+              "type": "ValidatorUpdate",
+              "longType": "ValidatorUpdate",
+              "fullType": "tm.ValidatorUpdate",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "app_hash",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TmEvent",
+          "longName": "TmEvent",
+          "fullName": "tm.TmEvent",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "req_init_chain",
+              "description": "",
+              "label": "",
+              "type": "RequestInitChain",
+              "longType": "RequestInitChain",
+              "fullType": "tm.RequestInitChain",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "res_init_chain",
+              "description": "",
+              "label": "",
+              "type": "ResponseInitChain",
+              "longType": "ResponseInitChain",
+              "fullType": "tm.ResponseInitChain",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "req_deliver_tx",
+              "description": "",
+              "label": "",
+              "type": "RequestDeliverTx",
+              "longType": "RequestDeliverTx",
+              "fullType": "tm.RequestDeliverTx",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "res_deliver_tx",
+              "description": "",
+              "label": "",
+              "type": "ResponseDeliverTx",
+              "longType": "ResponseDeliverTx",
+              "fullType": "tm.ResponseDeliverTx",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "req_begin_block",
+              "description": "",
+              "label": "",
+              "type": "RequestBeginBlock",
+              "longType": "RequestBeginBlock",
+              "fullType": "tm.RequestBeginBlock",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            },
+            {
+              "name": "res_begin_block",
+              "description": "",
+              "label": "",
+              "type": "ResponseBeginBlock",
+              "longType": "ResponseBeginBlock",
+              "fullType": "tm.ResponseBeginBlock",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "action",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "Validator",
+          "longName": "Validator",
+          "fullName": "tm.Validator",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "address",
+              "description": "",
+              "label": "",
+              "type": "bytes",
+              "longType": "bytes",
+              "fullType": "bytes",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "power",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidatorParams",
+          "longName": "ValidatorParams",
+          "fullName": "tm.ValidatorParams",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_key_types",
+              "description": "",
+              "label": "repeated",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "ValidatorUpdate",
+          "longName": "ValidatorUpdate",
+          "fullName": "tm.ValidatorUpdate",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "pub_key",
+              "description": "",
+              "label": "",
+              "type": "PublicKey",
+              "longType": "PublicKey",
+              "fullType": "tm.PublicKey",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "power",
+              "description": "",
+              "label": "",
+              "type": "int64",
+              "longType": "int64",
+              "fullType": "int64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "VersionParams",
+          "longName": "VersionParams",
+          "fullName": "tm.VersionParams",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "app_version",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "VoteInfo",
+          "longName": "VoteInfo",
+          "fullName": "tm.VoteInfo",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "validator",
+              "description": "",
+              "label": "",
+              "type": "Validator",
+              "longType": "Validator",
+              "fullType": "tm.Validator",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "signed_last_block",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    }
+  ],
+  "scalarValueTypes": [
+    {
+      "protoType": "double",
+      "notes": "",
+      "cppType": "double",
+      "csType": "double",
+      "goType": "float64",
+      "javaType": "double",
+      "phpType": "float",
+      "pythonType": "float",
+      "rubyType": "Float"
+    },
+    {
+      "protoType": "float",
+      "notes": "",
+      "cppType": "float",
+      "csType": "float",
+      "goType": "float32",
+      "javaType": "float",
+      "phpType": "float",
+      "pythonType": "float",
+      "rubyType": "Float"
+    },
+    {
+      "protoType": "int32",
+      "notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "int64",
+      "notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "uint32",
+      "notes": "Uses variable-length encoding.",
+      "cppType": "uint32",
+      "csType": "uint",
+      "goType": "uint32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int/long",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "uint64",
+      "notes": "Uses variable-length encoding.",
+      "cppType": "uint64",
+      "csType": "ulong",
+      "goType": "uint64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sint32",
+      "notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sint64",
+      "notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "fixed32",
+      "notes": "Always four bytes. More efficient than uint32 if values are often greater than 2^28.",
+      "cppType": "uint32",
+      "csType": "uint",
+      "goType": "uint32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "fixed64",
+      "notes": "Always eight bytes. More efficient than uint64 if values are often greater than 2^56.",
+      "cppType": "uint64",
+      "csType": "ulong",
+      "goType": "uint64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "sfixed32",
+      "notes": "Always four bytes.",
+      "cppType": "int32",
+      "csType": "int",
+      "goType": "int32",
+      "javaType": "int",
+      "phpType": "integer",
+      "pythonType": "int",
+      "rubyType": "Bignum or Fixnum (as required)"
+    },
+    {
+      "protoType": "sfixed64",
+      "notes": "Always eight bytes.",
+      "cppType": "int64",
+      "csType": "long",
+      "goType": "int64",
+      "javaType": "long",
+      "phpType": "integer/string",
+      "pythonType": "int/long",
+      "rubyType": "Bignum"
+    },
+    {
+      "protoType": "bool",
+      "notes": "",
+      "cppType": "bool",
+      "csType": "bool",
+      "goType": "bool",
+      "javaType": "boolean",
+      "phpType": "boolean",
+      "pythonType": "boolean",
+      "rubyType": "TrueClass/FalseClass"
+    },
+    {
+      "protoType": "string",
+      "notes": "A string must always contain UTF-8 encoded or 7-bit ASCII text.",
+      "cppType": "string",
+      "csType": "string",
+      "goType": "string",
+      "javaType": "String",
+      "phpType": "string",
+      "pythonType": "str/unicode",
+      "rubyType": "String (UTF-8)"
+    },
+    {
+      "protoType": "bytes",
+      "notes": "May contain any arbitrary sequence of bytes.",
+      "cppType": "string",
+      "csType": "ByteString",
+      "goType": "[]byte",
+      "javaType": "ByteString",
+      "phpType": "string",
+      "pythonType": "str",
+      "rubyType": "String (ASCII-8BIT)"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds proto documentation in json format, which may be useful with Docusaurus and [protobuffet](https://github.com/protobuffet/docusaurus-protobuffet/tree/master/packages/docusaurus-protobuffet).