### PR TITLE
CI: Ensure all manually created PRs are linked to an Issue

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -7,6 +7,8 @@ name: VerifyIssue
 
 "on":
   pull_request:
+    branches:
+      - '!vegaprotocol/api/renovate/**'
     types: [edited, synchronize, opened, reopened]
   check_run:
 

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -1,6 +1,4 @@
-
 ---
-
 
 # This workflow will inspect a pull request to ensure there is a linked issue or a
 # valid issue is mentioned in the body. If neither is present it fails the check and adds

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -12,11 +12,11 @@ name: VerifyIssue
 
 jobs:
   verify_linked_issue:
+    if: startsWith(github.head_ref, 'renovate/') != true
     runs-on: ubuntu-latest
     name: Ensure Pull Request has a linked issue.
     steps:
       - name: Verify Linked Issue
         uses: hattan/verify-linked-issue-action@95c0d0150d7e7687e45a76fbf0b0c6aa8daef288
-        if: startsWith(github.head_ref, 'renovate') == false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -1,0 +1,23 @@
+
+---
+
+
+# This workflow will inspect a pull request to ensure there is a linked issue or a
+# valid issue is mentioned in the body. If neither is present it fails the check and adds
+# a comment alerting users of this missing requirement. Edit to test.
+name: VerifyIssue
+
+"on":
+  pull_request:
+    types: [edited, synchronize, opened, reopened]
+  check_run:
+
+jobs:
+  verify_linked_issue:
+    runs-on: ubuntu-latest
+    name: Ensure Pull Request has a linked issue.
+    steps:
+      - name: Verify Linked Issue
+        uses: hattan/verify-linked-issue-action@95c0d0150d7e7687e45a76fbf0b0c6aa8daef288
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -7,8 +7,6 @@ name: VerifyIssue
 
 "on":
   pull_request:
-    branches:
-      - '!vegaprotocol/api/renovate/**'
     types: [edited, synchronize, opened, reopened]
   check_run:
 
@@ -19,5 +17,6 @@ jobs:
     steps:
       - name: Verify Linked Issue
         uses: hattan/verify-linked-issue-action@95c0d0150d7e7687e45a76fbf0b0c6aa8daef288
+        if: startsWith(github.head_ref, 'renovate') == false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As per the description in #300 this adds an action to verify that all PRs have linked issues noted in the body of the PR.

closes #300 