### PR TITLE
Bump path-parse to 1.0.7 (CVE-2021-23343)

### DIFF
--- a/grpc/clients/js/package-lock.json
+++ b/grpc/clients/js/package-lock.json
@@ -15,6 +15,7 @@
         "@typescript-eslint/parser": "4.29.1",
         "eslint": "7.32.0",
         "google-protobuf": "3.17.3",
+        "path-parse": "1.0.7",
         "tape": "5.3.1",
         "tinyify": "3.0.0",
         "ts-protoc-gen": "0.15.0",
@@ -2748,9 +2749,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -5982,9 +5983,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/grpc/clients/js/package.json
+++ b/grpc/clients/js/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/parser": "4.29.1",
     "eslint": "7.32.0",
     "google-protobuf": "3.17.3",
+    "path-parse": "1.0.7",
     "tape": "5.3.1",
     "tinyify": "3.0.0",
     "ts-protoc-gen": "0.15.0",


### PR DESCRIPTION
This PR bumps path-parse to v1.0.7, as recommended by dependabot.