### PR TITLE
Update dependency @types/google-protobuf to v3.15.5

### DIFF
--- a/grpc/clients/js/package-lock.json
+++ b/grpc/clients/js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.40.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/google-protobuf": "3.15.3",
+        "@types/google-protobuf": "3.15.5",
         "@types/node": "14.17.9",
         "@typescript-eslint/eslint-plugin": "4.29.1",
         "@typescript-eslint/parser": "4.29.1",
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@types/google-protobuf": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.3.tgz",
-      "integrity": "sha512-MDpu7lit927cdLtBzTPUFjXGANFUnu5ThPqjygY8XmCyI/oDlIA0jAi4sffGOxYaLK2CCxAuU9wGxsgAQbA6FQ==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
+      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -4002,9 +4002,9 @@
       }
     },
     "@types/google-protobuf": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.3.tgz",
-      "integrity": "sha512-MDpu7lit927cdLtBzTPUFjXGANFUnu5ThPqjygY8XmCyI/oDlIA0jAi4sffGOxYaLK2CCxAuU9wGxsgAQbA6FQ==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz",
+      "integrity": "sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==",
       "dev": true
     },
     "@types/json-schema": {

--- a/grpc/clients/js/package.json
+++ b/grpc/clients/js/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/vegaprotocol/api#readme",
   "devDependencies": {
-    "@types/google-protobuf": "3.15.3",
+    "@types/google-protobuf": "3.15.5",
     "@types/node": "14.17.9",
     "@typescript-eslint/eslint-plugin": "4.29.1",
     "@typescript-eslint/parser": "4.29.1",


### PR DESCRIPTION
This PR updates dependency `@types/google-protobuf` to `v3.15.5`, as dependabot tried to do (but for some reason did not update `package-lock.json`).